### PR TITLE
docs: make this repo canonical rather than a generated mirror

### DIFF
--- a/.github/leakcheck/POLICY.md
+++ b/.github/leakcheck/POLICY.md
@@ -1,8 +1,8 @@
 # What may not be published from this repository
 
-This repository is public and it is a **mirror**: it is the distribution point for a plugin
-whose source lives elsewhere. Two consequences follow, and they are the whole reason this
-policy exists.
+This repository is public, and it is both where the plugin is developed and the point it is
+distributed from. Every commit here is a publication. Two consequences follow, and they are
+the whole reason this policy exists.
 
 **Nothing here can be unpublished.** A blob that was pushed stays reachable, a merged pull
 request keeps its diff, and forks and clones are made within minutes of a push. Deleting a

--- a/.github/scripts/llm-leak-review.mjs
+++ b/.github/scripts/llm-leak-review.mjs
@@ -136,7 +136,7 @@ for (const a of added) {
 const policyPath = join(REPO, '.github/leakcheck/POLICY.md');
 const policy = existsSync(policyPath) ? readFileSync(policyPath, 'utf8') : '';
 
-const SYSTEM = `You review changes to a PUBLIC repository that mirrors a plugin for a closed-source
+const SYSTEM = `You review changes to a PUBLIC repository holding a plugin for a closed-source
 product called Mubit. Your single job is to find text that publishes something the policy below
 keeps private. You are not a code reviewer: ignore bugs, style, naming and test coverage.
 

--- a/README.md
+++ b/README.md
@@ -31,33 +31,26 @@ Opens the [Mubit console](https://console.mubit.ai), signs you in, and stores a 
 machine after checking it against your instance. No browser — over SSH, say — is covered in the
 plugin README.
 
-## This is a generated repository — do not edit it here
+## Contributing
 
-Contents are published from Mubit's source repository on release. Any commit made directly here
-is overwritten by the next publish.
-
-```
-source repository
-  ├── .claude-plugin/marketplace.json ──┐
-  └── integrations/claude-code/ ────────┤ published on release
-                                        ▼
-mubit-ai/claude-plugins (this repo)  →  git clone by Claude Code  →  a user's plugin dir
-```
+**This repository is where the plugin is developed.** Open pull requests here; `main` is
+protected and takes them through review. There is no other tree that this one is generated
+from, and nothing here is regenerated on release — an edit made here is the edit that ships.
 
 Claude Code fetches a GitHub marketplace with `git clone --depth 1`, using your own git
 credentials — there is no separate plugin token. If your git is configured for SSH only, run
 `gh auth setup-git` first; the clone URL is always HTTPS, even for sources written as `git@`.
 
-The `integrations/claude-code` path is preserved deliberately: the marketplace entry's `source`
-is the marketplace-relative path `./integrations/claude-code`, which resolves inside whichever
-repository served the catalog. Keeping the same path means `marketplace.json` needs no rewriting
-when it is published here, so there is nothing that can drift between the two copies.
+The `integrations/claude-code` path is load-bearing: the marketplace entry's `source` is the
+marketplace-relative path `./integrations/claude-code`, which resolves inside whichever
+repository served the catalog. Moving the plugin to the repository root would mean rewriting
+`marketplace.json`, so the path stays where it is.
 
-What is published is the plugin's tracked files, minus development-only scripts and QA
-transcripts written against a developer's own checkout. What
-runs on your machine is exactly what you see here — Claude Code executes this directory as
-fetched, with no build step, which is why `hooks/dist/`, `mcp/dist/` and `bin/statusline.mjs`
-are committed artifacts rather than build output.
+What runs on your machine is exactly what you see here — Claude Code executes this directory
+as fetched, with no build step and no `npm install`. That is why `hooks/dist/`, `mcp/dist/`
+and `bin/statusline.mjs` are committed artifacts rather than build output, and why a change
+to a hook or to `lib/` has to be committed together with the bundle it rebuilds. CI rebuilds
+and runs `git diff --exit-code`, so the two cannot drift.
 
 ## Verifying what you are about to run
 

--- a/integrations/claude-code/esbuild.config.mjs
+++ b/integrations/claude-code/esbuild.config.mjs
@@ -54,9 +54,9 @@ const MCP_SERVER_BUILD = 'npm --prefix ../mcp ci && npm --prefix ../mcp run buil
  * The version stamped into the launcher as `__MUBIT_MCP_VERSION__`.
  *
  * The sibling manifest is the authority: it is the package `mcp/dist/server.js` was bundled
- * from. In the generated `claude-plugins` mirror that sibling does not exist — the mirror
- * carries this one plugin and vendors the server bundle — and reading it there threw at
- * module scope, which made `npm run build` unusable for every other target too.
+ * from. In a checkout that carries only this plugin that sibling does not exist — the server
+ * bundle is vendored there instead — and reading it threw at module scope, which made
+ * `npm run build` unusable for every other target too.
  *
  * This plugin's own version is the right fallback rather than a guess: the two ship in
  * lockstep (release tooling holds them together, and `manifests.test.mjs` enforces
@@ -206,7 +206,7 @@ const targets = [
 // that proves nothing, in precisely the place a stale server bundle already shipped once.
 //
 // The one exception is a checkout where the sibling is not merely uncompiled but absent:
-// the generated `claude-plugins` mirror vendors `mcp/dist/server.js` and has no `../mcp` to
+// a checkout carrying only this plugin vendors `mcp/dist/server.js` and has no `../mcp` to
 // build from, so the target is structurally unbuildable there and the refusal above blocks
 // every *other* target with it. `MUBIT_CC_BUILD_SKIP_SERVER=1` opts out explicitly — which
 // is the honest shape for this, where a silent skip would not be: the operator states that
@@ -220,8 +220,8 @@ if (!has(MCP_SERVER_ENTRY) && process.env.MUBIT_CC_BUILD_SKIP_SERVER !== '1') {
     + `      ${MCP_SERVER_BUILD}\n`
     + '  Refusing to continue: skipping this target would leave the committed server bundle in\n'
     + '  place and report success.\n'
-    + '  If this checkout has no ../mcp at all (the generated claude-plugins mirror vendors the\n'
-    + '  server bundle instead), say so: MUBIT_CC_BUILD_SKIP_SERVER=1.');
+    + '  If this checkout has no ../mcp at all (it vendors the server bundle instead), say so:\n'
+    + '      MUBIT_CC_BUILD_SKIP_SERVER=1');
   process.exit(1);
 }
 


### PR DESCRIPTION
The README told readers this tree is published from somewhere else and that any commit made here is overwritten by the next publish. That is no longer the plan, and believing it is now actively dangerous: `cwd-changed.mjs`, `pre-tool.mjs` and `recall-refresh.mjs` exist only here, so a publish in the other direction would delete them — and a reader who trusts the old paragraph edits the wrong tree and loses the work.

**What changes**

- `README.md` — the "generated repository" section and the source-repo diagram are replaced by a contributing note: pull requests land here, `main` is protected, nothing is regenerated on release. The material that is still true stays — why `integrations/claude-code` is a load-bearing path, and why `hooks/dist`, `mcp/dist` and `bin/` are committed artifacts.
- `.github/leakcheck/POLICY.md:3` — the opening premise, restated. **No rule is weakened.** Both consequences the policy rests on are independent of which repository is upstream: a pushed blob is permanent, and a client cannot keep the wire secret. Every category, threshold and enforcement step is untouched.
- Three build/tooling comments that described this checkout as "the generated mirror" — a comment contradicting the README is how the old topology survives a rewrite.

**Branch protection**

The plan for this change included enabling protection on `main`. It is already in place and already stronger than asked for, so there is nothing to do:

| Setting | State |
| --- | --- |
| Required approving reviews | 1 |
| Enforce for admins | on (no bypass) |
| Force pushes | blocked |
| Deletions | blocked |

That is what blocks the dormant `git push origin HEAD:main` workflow in the other repository. It is a real defence and not a complete one — the workflow stays armed, has never run, and is not on that repository's default branch.

**Verification**

`node .github/scripts/leakcheck.mjs --strict` exits 0. No new findings; the `mirror-process-disclosure` rule is unaffected by this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DXd54icawcQ7xvHdpj7RFu