### PR TITLE
feat(claude-code): three tools that were excluded for reasons that stopped being true

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -15,7 +15,7 @@
       "repository": "https://github.com/mubit-ai/claude-plugins",
       "license": "Apache-2.0",
       "keywords": ["memory", "mubit", "long-term-memory", "lessons", "recall"],
-      "contextCost": { "value": 3725, "cached": 0 }
+      "contextCost": { "value": 4564, "cached": 0 }
     }
   ]
 }

--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -111,7 +111,7 @@ one per `if` pattern.)
 Every hook exits 0, always. A memory layer has no business breaking a prompt — a dead server,
 an unwritable data dir, or a corrupt state file costs you a memory, never a turn.
 
-### Eight skills and one subagent
+### The skills and one subagent
 
 | Command | Use it for |
 | --- | --- |
@@ -123,22 +123,33 @@ an unwritable data dir, or a corrupt state file costs you a memory, never a turn
 | `/mubit-memory:reflect` | Extract lessons from this session mid-flight, rather than waiting for `SessionEnd`. |
 | `/mubit-memory:forget` | Delete a lesson, or down-weight one that is merely wrong. |
 | `/mubit-memory:dashboard` | Open a local page over everything above: browse and search lessons, see what recall cost per prompt, watch ingest health. Loopback only, and the one skill the model cannot invoke for you. |
+| `/mubit-memory:strategies` | Read the pattern *across* many lessons rather than any single one — what this project keeps doing, and keeps getting wrong. |
+| `/mubit-memory:checkpoint` | Save a named snapshot of where a run has got to, stored verbatim, before risky work. The half of `PreCompact` you can ask for. |
+| `/mubit-memory:memory-health` | Report what is actually stored: entry counts, staleness, contradictions. The store, not the connection. |
 | `@mubit-memory:mubit-recall` | Subagent: multi-angle memory search in an isolated context, returns a synthesis instead of raw evidence. |
 
-### Ten MCP tools
+### Thirteen MCP tools
 
-The bundled MCP server carries 21 tools and registers ten of them by default — the other
-eleven cost you nothing until you ask for them:
+The bundled MCP server carries 21 tools and registers thirteen of them by default — the other
+eight cost you nothing until you ask for them:
 
 ```
 mubit_learned   mubit_recall   mubit_outcome   mubit_reflect   mubit_lessons
 mubit_diagnose  mubit_archive  mubit_dereference  mubit_forget  mubit_status
+mubit_strategies  mubit_checkpoint  mubit_memory_health
 ```
 
-The other eleven are excluded because a hook already does the job better
-(`mubit_remember`, `mubit_context`, `mubit_checkpoint`, `mubit_register_agent`,
-`mubit_list_agents`) or because they have no Claude Code surface (the multi-agent
-orchestration group). Nothing is removed — restore any of them by name with `mcpTools`.
+The other eight are excluded because a hook already does the job better (`mubit_remember`,
+`mubit_context`) or because they have no Claude Code surface (`mubit_register_agent`,
+`mubit_list_agents` and the rest of the multi-agent orchestration group). Nothing is removed:
+restore any of them by name with `mcpTools`.
+
+The last three on that list were excluded until each had a skill to reach it. A checkpoint is
+not what `PreCompact` does — the hook fires when the window fills, which is the one moment you
+cannot ask for, and `mubit_checkpoint` is the marker you name yourself. `mubit_strategies`
+reads the pattern across many lessons where every other retrieval verb reads individual ones.
+`mubit_memory_health` answers the route `/mubit-memory:doctor` used to tell you to `POST` by
+hand.
 
 ### A status line
 
@@ -286,7 +297,7 @@ that cache, and writing credentials invalidates it immediately rather than after
 | `outcomeMode` | `implicit` | `MUBIT_CC_OUTCOME_MODE` | `implicit`: a turn whose reply carried the recalled memory's own vocabulary is attributed to those memories; a turn that carried none of it is recorded as `neutral` against the run and attributed to no entry, so an injection nobody used is counted rather than being invisible. `explicit`: only the model's own `mubit_outcome` calls count. `off`: no attribution, and no measurement of it either. |
 | `statusLine` | `true` | `MUBIT_CC_STATUSLINE` | Render the status line. When false it prints an empty line and exits 0 rather than erroring per frame. |
 | `preToolWarnings` | `false` | `MUBIT_CC_PRE_TOOL_WARNINGS` | Show the model a matching stored `rule` just before an `rm` or `git push` runs. Warnings only — it never blocks, rewrites or asks about a tool call, and the filter that decides when it runs at all is best-effort, so treat it as a reminder and use Claude Code's permission system for anything that has to hold. Off by default: this is the one setting that can put text in front of a tool call. |
-| `mcpTools` | `""` (the curated ten) | `MUBIT_MCP_TOOLS` | Comma-separated allowlist. A list you supply is used verbatim, not unioned with the default — that is how you ask for only `mubit_recall`. |
+| `mcpTools` | `""` (the curated thirteen) | `MUBIT_MCP_TOOLS` | Comma-separated allowlist. A list you supply is used verbatim, not unioned with the default — that is how you ask for only `mubit_recall`. |
 | `mcpLessonScope` | `run` | `MUBIT_MCP_LESSON_SCOPE` | The widest scope a lesson written by an MCP tool may claim: `run`, `session` or `global`. Anything above `run` is read back by unrelated runs, so the default keeps an agent-written lesson in the run that wrote it — with `runStrategy: per-directory`, that is the project it was written in. Raise it if you want agent-written rules to follow you between projects; reflection promotes a lesson beyond its run either way. |
 
 ### Environment-only settings

--- a/integrations/claude-code/lib/config.mjs
+++ b/integrations/claude-code/lib/config.mjs
@@ -40,14 +40,25 @@ import { dataDir as resolveDataRoot, readJson, writeJsonAtomic } from './state.m
 // ---------------------------------------------------------------------------
 
 /**
- * §8.2 — ten of the MCP server's twenty-one tools. A blank `mcpTools` /
- * `MUBIT_MCP_TOOLS` means this curated set, never "none": the excluded eleven
+ * §8.2 — thirteen of the MCP server's twenty-one tools. A blank `mcpTools` /
+ * `MUBIT_MCP_TOOLS` means this curated set, never "none": the excluded eight
  * are excluded because a hook already does the job better, not because tools
  * are off by default.
+ *
+ * The last three were promoted out of that exclusion. `mubit_checkpoint` is the
+ * voluntary half of what `PreCompact` does involuntarily — a marker a user names
+ * before risky work, which a hook firing on the host's schedule cannot be asked
+ * for. `mubit_strategies` reads the pattern across many lessons where every other
+ * retrieval verb reads individual ones. `mubit_memory_health` answers the route
+ * the doctor skill used to tell its reader to POST by hand.
+ *
+ * `mcp/src/launch.mjs` carries the same list, and the two must move together:
+ * this one is what a resolved config reports, that one is the launcher's floor.
  */
 const DEFAULT_MCP_TOOLS = [
   'mubit_learned', 'mubit_recall', 'mubit_outcome', 'mubit_reflect', 'mubit_lessons',
   'mubit_diagnose', 'mubit_archive', 'mubit_dereference', 'mubit_forget', 'mubit_status',
+  'mubit_strategies', 'mubit_checkpoint', 'mubit_memory_health',
 ];
 
 /** §7: `config.json` — cached resolved config, keyed by an input hash. */

--- a/integrations/claude-code/mcp/src/launch.mjs
+++ b/integrations/claude-code/mcp/src/launch.mjs
@@ -41,13 +41,33 @@ import { installFetchGuard, resolveCeiling } from './egress.mjs';
 import { INSTRUCTIONS, installInstructionsGuard } from './instructions.mjs';
 
 /**
- * §8.2 — ten of the server's twenty-one tools, in the guide's order.
+ * §8.2 — thirteen of the server's twenty-one tools, in the guide's order.
  *
- * A blank `mcpTools` means this curated set, never "none" and never all 21: the eleven
- * excluded verbs are ones a hook already does better (`mubit_remember`, `mubit_context`,
- * `mubit_checkpoint`, `mubit_register_agent`, `mubit_list_agents`) or that have no Claude
- * Code surface at all (the multi-agent orchestration group). Nothing is removed — users
- * restore any of them through `mcpTools` / `MUBIT_MCP_TOOLS`.
+ * A blank `mcpTools` means this curated set, never "none" and never all 21: the eight
+ * excluded verbs are ones a hook already does better (`mubit_remember`, `mubit_context`)
+ * or that have no Claude Code surface at all (`mubit_register_agent`, `mubit_list_agents`
+ * and the rest of the multi-agent orchestration group). Nothing is removed — users restore
+ * any of them through `mcpTools` / `MUBIT_MCP_TOOLS`.
+ *
+ * The last three arrived later, and each was excluded for a reason that turned out not to
+ * hold.
+ *
+ * `mubit_checkpoint` was listed here as work a hook already did better. It is not the same
+ * work. The `PreCompact` hook checkpoints on the host's schedule — when the window fills —
+ * which is precisely the moment nobody can ask for. "Save where we are before I try this"
+ * is a decision a person makes, and there was no way to express it. The hook and the tool
+ * are the involuntary and the voluntary halves of one thing, not two paths to one.
+ *
+ * `mubit_strategies` reads the pattern *across* many lessons. Every retrieval verb above it
+ * reads individual ones, so this was not a duplicated lane; it was a lane nobody opened.
+ *
+ * `mubit_memory_health` was excluded while `skills/doctor/SKILL.md` told its reader to
+ * `POST /v2/control/memory_health` by hand at step 3. Withholding the tool never removed
+ * the need for the route — it only moved the call off the tool surface and into prose.
+ *
+ * Each of the three ships with a skill (`strategies`, `checkpoint`, `memory-health`): an
+ * allowlisted tool with nothing to invoke it is schema cost without a surface, which is the
+ * failure the curation exists to prevent.
  *
  * `lib/config.mjs` carries the same list; this copy is the launcher's floor for the case
  * where config resolution hands back an empty list.
@@ -55,6 +75,7 @@ import { INSTRUCTIONS, installInstructionsGuard } from './instructions.mjs';
 export const DEFAULT_ALLOWLIST = [
   'mubit_learned', 'mubit_recall', 'mubit_outcome', 'mubit_reflect', 'mubit_lessons',
   'mubit_diagnose', 'mubit_archive', 'mubit_dereference', 'mubit_forget', 'mubit_status',
+  'mubit_strategies', 'mubit_checkpoint', 'mubit_memory_health',
 ];
 
 /**

--- a/integrations/claude-code/scripts/context-cost.json
+++ b/integrations/claude-code/scripts/context-cost.json
@@ -1,44 +1,53 @@
 {
-  "measuredAt": "2026-08-23T17:20:47.012Z",
-  "value": 3725,
+  "measuredAt": "2026-08-24T11:26:44.100Z",
+  "value": 4564,
   "cached": 0,
-  "curatedValue": 3725,
+  "curatedValue": 4564,
   "allowlistHonoured": true,
   "method": "word/number/symbol segmentation; see the header of scripts/measure-context-cost.mjs",
   "surface": {
     "allowlist": [
       "mubit_archive",
+      "mubit_checkpoint",
       "mubit_dereference",
       "mubit_diagnose",
       "mubit_forget",
       "mubit_learned",
       "mubit_lessons",
+      "mubit_memory_health",
       "mubit_outcome",
       "mubit_recall",
       "mubit_reflect",
-      "mubit_status"
+      "mubit_status",
+      "mubit_strategies"
     ],
     "registered": [
       "mubit_archive",
+      "mubit_checkpoint",
       "mubit_dereference",
       "mubit_diagnose",
       "mubit_forget",
       "mubit_learned",
       "mubit_lessons",
+      "mubit_memory_health",
       "mubit_outcome",
       "mubit_recall",
       "mubit_reflect",
-      "mubit_status"
+      "mubit_status",
+      "mubit_strategies"
     ],
     "skills": [
       "auth",
+      "checkpoint",
       "dashboard",
       "doctor",
       "forget",
+      "memory-health",
       "recall",
       "reflect",
       "remember",
-      "setup"
+      "setup",
+      "strategies"
     ],
     "agents": [
       "mubit-recall"
@@ -46,9 +55,9 @@
   },
   "breakdown": {
     "toolSchemas": {
-      "tokens": 2907,
-      "chars": 7981,
-      "count": 10
+      "tokens": 3515,
+      "chars": 9658,
+      "count": 13
     },
     "serverInstructions": {
       "tokens": 356,
@@ -56,14 +65,14 @@
       "count": 1
     },
     "curatedToolSchemas": {
-      "tokens": 2907,
-      "chars": 7981,
-      "count": 10
+      "tokens": 3515,
+      "chars": 9658,
+      "count": 13
     },
     "skillFrontmatter": {
-      "tokens": 400,
-      "chars": 1340,
-      "count": 8
+      "tokens": 631,
+      "chars": 2152,
+      "count": 11
     },
     "agentFrontmatter": {
       "tokens": 62,

--- a/integrations/claude-code/scripts/measure-context-cost.mjs
+++ b/integrations/claude-code/scripts/measure-context-cost.mjs
@@ -75,13 +75,14 @@ const LAUNCHER = join(PLUGIN_ROOT, 'mcp', 'dist', 'index.js');
 const STAMP = join(PLUGIN_ROOT, 'scripts', 'context-cost.json');
 const MARKETPLACE = join(REPO_ROOT, '.claude-plugin', 'marketplace.json');
 
-/** The host prefixes a plugin-provided server's tools with this. 30 chars, ten times over. */
+/** The host prefixes a plugin-provided server's tools with this. 30 chars, once per tool. */
 const QUALIFIED_PREFIX = 'mcp__plugin_mubit-memory_mubit__';
 
-/** §8.2 — the curated ten a blank `mcpTools` resolves to. Kept in sync by verify-manifests. */
+/** §8.2 — the curated set a blank `mcpTools` resolves to. Kept in sync by verify-manifests. */
 const DEFAULT_ALLOWLIST = [
   'mubit_learned', 'mubit_recall', 'mubit_outcome', 'mubit_reflect', 'mubit_lessons',
   'mubit_diagnose', 'mubit_archive', 'mubit_dereference', 'mubit_forget', 'mubit_status',
+  'mubit_strategies', 'mubit_checkpoint', 'mubit_memory_health',
 ];
 
 const HANDSHAKE_MS = 20_000;
@@ -360,7 +361,7 @@ function report(r) {
   if (!r.allowlistHonoured) {
     process.stdout.write(
       `\nThis server registers all ${b.toolSchemas.count} tools, so \`mcpTools\` is inert and every\n`
-      + `user pays for every tool. With the curated ten honoured the same surface costs\n`
+      + `user pays for every tool. With the curated set honoured the same surface costs\n`
       + `${r.curatedValue} tokens, ${r.value - r.curatedValue} fewer.\n`
       + 'The server is bundled from the in-repo @mubit-ai/mcp, which reads MUBIT_MCP_TOOLS (§8.1).\n'
       + 'A server that ignores it is a stale bundle — rebuild:\n'

--- a/integrations/claude-code/scripts/verify-manifests.mjs
+++ b/integrations/claude-code/scripts/verify-manifests.mjs
@@ -30,10 +30,11 @@ const CONN_STATES = [
   'ready', 'unreachable', 'server_error', 'auth_failed', 'not_responding', 'unconfigured',
 ];
 
-/** §8.2 — ten of the twenty-one tools. */
+/** §8.2 — thirteen of the twenty-one tools; the last three were promoted in W2-1. */
 const DEFAULT_ALLOWLIST = [
   'mubit_learned', 'mubit_recall', 'mubit_outcome', 'mubit_reflect', 'mubit_lessons',
   'mubit_diagnose', 'mubit_archive', 'mubit_dereference', 'mubit_forget', 'mubit_status',
+  'mubit_strategies', 'mubit_checkpoint', 'mubit_memory_health',
 ];
 
 const P = {

--- a/integrations/claude-code/skills/checkpoint/SKILL.md
+++ b/integrations/claude-code/skills/checkpoint/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: checkpoint
+description: Save a named snapshot of where this run has got to, stored verbatim. Use when the user is about to do something risky or destructive, when a compaction is coming that they want to survive on their own terms, or when they ask to mark a point they may need to come back to.
+disable-model-invocation: false
+tools: ["mcp__plugin_mubit-memory_mubit__mubit_checkpoint"]
+---
+
+Call `mubit_checkpoint` — `POST /v2/control/checkpoint` — with the state you are holding.
+`snapshot` is the only required argument; `label` is a short name the user can ask for later
+and is worth passing every time.
+
+## What goes in `snapshot`
+
+It is stored **verbatim and unsummarised**. Nothing rewrites it, shortens it or extracts
+anything from it, which cuts both ways: whatever you write is exactly what a future reader
+gets, and a one-line headline restores nothing.
+
+Write it for someone who has lost the conversation entirely — which is the only situation in
+which it will ever be read. What we were doing and why, what is finished, what is half-done
+and how far, the exact branch, file paths and commands in play, and the next concrete step.
+Prose is fine. Length is fine. This is the one write in the plugin where compressing is the
+mistake.
+
+## A checkpoint is run state, not knowledge
+
+This is the distinction that decides whether to use this skill at all.
+
+**Run state** is true now and false tomorrow: "mid-migration on `feat/x`, three files edited,
+the codex suite still red on two dist tests". It is worthless in six months and nobody wants
+it surfacing in an unrelated session. That is a checkpoint.
+
+**Knowledge** is true regardless of which run learned it: "`npm run verify` deletes the
+vendored server bundle", "this team wants small PRs". That is a lesson — save it with
+`/mubit-memory:remember`, which classifies it and gives it a scope so it reaches later
+sessions on purpose.
+
+Getting this backwards costs something in both directions. A checkpoint used for knowledge
+buries a durable fact in a snapshot nobody will search for. A lesson used for run state turns
+memory into a session log, and every later recall pays for it.
+
+## When to call it
+
+The `PreCompact` hook already checkpoints on the way into a compaction. That is the automatic
+one, and it fires on the host's schedule — when the window fills — which is exactly the moment
+nobody can ask for. This tool is the half a person asks for: before a destructive migration, a
+history rewrite, a long refactor, or a deliberate `/clear` the user wants to walk back from.
+
+Do not checkpoint reflexively or on a timer. Each call is a durable write, and a run littered
+with near-identical snapshots is harder to recover from than one with three good ones.

--- a/integrations/claude-code/skills/doctor/SKILL.md
+++ b/integrations/claude-code/skills/doctor/SKILL.md
@@ -2,7 +2,7 @@
 name: doctor
 description: Diagnose Mubit connectivity, memory health, and stuck ingest jobs. Use when memory looks empty, captures are not landing, or the status line shows a failure glyph.
 disable-model-invocation: false
-tools: ["mcp__plugin_mubit-memory_mubit__mubit_status", "mcp__plugin_mubit-memory_mubit__mubit_diagnose"]
+tools: ["mcp__plugin_mubit-memory_mubit__mubit_status", "mcp__plugin_mubit-memory_mubit__mubit_diagnose", "mcp__plugin_mubit-memory_mubit__mubit_memory_health"]
 ---
 
 Work in this order and stop at the first thing that is broken. Each step costs more than the
@@ -52,9 +52,11 @@ one before it, and the cheap steps answer most questions.
    one route that answers without a key, so a healthy response here alongside a failing
    control-plane call points squarely at auth. It returns the plain string `OK`, not JSON —
    parsing it as JSON is itself a way to invent a `server_error` that is not there.
-3. **Check memory health** — `POST /v2/control/memory_health {run_id}`. This is what
-   distinguishes "nothing was ever written" from "things were written and are not coming
-   back".
+3. **Check memory health** — `mubit_memory_health`, or `POST /v2/control/memory_health
+   {run_id}` directly. This is what distinguishes "nothing was ever written" from "things were
+   written and are not coming back". It inspects the store; step 2 inspected the connection,
+   and a healthy answer there says nothing at all about this one.
+   `/mubit-memory:memory-health` is the same call with the reading guide attached.
 4. **Poll the run's ingest jobs.** `runs/<run_id>/jobs.json` holds the last 20 accepted job
    ids; poll each with `GET /v2/control/ingest/jobs/<job_id>?run_id=<run_id>`. Accepted means
    queued, not stored. A job stuck in `queued` for minutes means the instance accepted the

--- a/integrations/claude-code/skills/memory-health/SKILL.md
+++ b/integrations/claude-code/skills/memory-health/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: memory-health
+description: Report what is actually in Mubit memory — entry counts, staleness, contradictions and per-section health. Use when memory looks empty or stale and you need to know whether anything was ever stored, rather than whether the instance is reachable.
+disable-model-invocation: false
+tools: ["mcp__plugin_mubit-memory_mubit__mubit_memory_health", "mcp__plugin_mubit-memory_mubit__mubit_status"]
+---
+
+Call `mubit_memory_health` — `POST /v2/control/memory_health` — and report what it says about
+the store. `limit` (1 to 500) is how many entries it samples; the default is enough unless the
+user is specifically asking about an old part of a large run.
+
+## This inspects the store. `mubit_status` inspects the connection.
+
+The two answer different questions and are easy to confuse, because both fail as "memory
+isn't working".
+
+- **`mubit_status`** dials the instance. It tells you whether there is something at the other
+  end, whether the key is accepted, and which typed `ConnState` applies. It knows nothing
+  about what is stored.
+- **`mubit_memory_health`** asks what is in there: how many entries, how stale they are,
+  whether any of them contradict each other, and how each section is doing. It says nothing
+  about the connection — if the instance is unreachable this call does not answer at all.
+
+So a healthy connection over an empty store and a full store behind a dead endpoint look
+identical from the status line, and they have opposite fixes. Answer the question the user
+actually asked before offering a remedy for the other one.
+
+## Reading the answer
+
+- **Zero entries, connection fine.** Nothing was ever written. Check that capture is on, and
+  remember that an accepted ingest is *queued*, not stored — a run that just started can be
+  legitimately empty for a minute.
+- **Entries present, but recall keeps returning nothing.** The store is not the problem.
+  That is a retrieval or scope question: go to `/mubit-memory:doctor` step 1 and read
+  `recall.empty_reason` from the local status marker, which names the cause outright.
+- **Contradictions.** Two stored lessons that disagree. Neither is automatically wrong and
+  deleting both loses the argument: prefer a negative `mubit_outcome` on the one that turned
+  out false, or `/mubit-memory:forget` if it should never have existed. Report the pair to the
+  user rather than picking a winner yourself.
+- **Staleness.** Old is not broken. Say so — a lesson that has not been touched in months is
+  usually one that has not been contradicted either.
+
+`session_id` and `user_id` are best left out: the launcher already passes this run's id, and
+`user_id` is a retrieval filter, so supplying a value nothing was captured under reports an
+empty store that is not empty.
+
+This is step 3 of `/mubit-memory:doctor`, which walks the whole ladder cheapest check first.
+Use the doctor skill when the complaint is vague; use this one when the question is already
+narrowed to what memory contains. Do not poll it in a loop — it samples the store, and the
+answer does not change between turns.

--- a/integrations/claude-code/skills/strategies/SKILL.md
+++ b/integrations/claude-code/skills/strategies/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: strategies
+description: Surface the pattern across many stored lessons rather than any single one. Use when the user asks what memory has learned in general, why the same class of mistake keeps recurring, or how this project tends to work — not when they have one specific question.
+disable-model-invocation: false
+tools: ["mcp__plugin_mubit-memory_mubit__mubit_strategies", "mcp__plugin_mubit-memory_mubit__mubit_lessons"]
+---
+
+Call `mubit_strategies` — `POST /v2/control/strategies` — and report the strategies it returns
+in the user's own terms: what the pattern is, and what it was inferred from. Ask for a small
+number and report all of them; a wall of generalisations is less useful than three good ones.
+
+## The one thing to be clear about
+
+**`mubit_strategies` is the pattern *across* lessons. `mubit_lessons` reads the individual
+lessons themselves.**
+
+Every other retrieval tool here answers with entries. `mubit_recall` finds the lessons that
+match a question, `mubit_lessons` lists the catalogue, `mubit_diagnose` matches an error's
+shape, `mubit_dereference` fetches the one whose `reference_id` you already hold. This is the
+only one that answers with a *shape over* many of them: it clusters stored lessons into
+emergent strategies, so what comes back is a generalisation the server derived, not a record
+anybody wrote.
+
+That makes the choice easy in both directions. "Why do we keep breaking the build the same
+way?" and "what has this project learned about testing?" are strategy questions. "What did we
+decide about the recall budget?" is not — that has one answer, and `mubit_recall` finds it
+faster and quotes it. Do not reach for this tool to locate a single lesson; it will hand back
+a summary of a cluster the lesson happens to sit in.
+
+## Arguments
+
+- `max_strategies` — 1 to 50. Ask for five to ten. The value of the answer is that it is
+  short; fifty clusters over a few dozen lessons is the same information with the pattern
+  taken back out.
+- `lesson_types` — narrows which lessons get clustered, when the user is asking about one
+  kind of thing ("what have we learned about failures?").
+- `session_id` and `user_id` — leave both out. The launcher already passes this run's id, and
+  `user_id` is a retrieval *filter* rather than a label: a value nothing was captured under
+  matches nothing, so inventing one is how you get an empty answer from a full store.
+
+## Reporting it
+
+A strategy is inferred, not stated. It has less standing than a `rule`, which somebody wrote
+down on purpose and which is enforced as written. Say which you are relaying — presenting a
+clustered generalisation as though the user had asked for it is how a plausible pattern
+becomes a fact nobody agreed to.
+
+An empty or thin answer is usually not a fault. Clustering needs a body of lessons to cluster,
+and a young run does not have one yet. Before reporting that memory has no patterns, check
+that it has anything at all: `/mubit-memory:memory-health` distinguishes "nothing was ever
+stored" from "stored, and there is genuinely no pattern in it".

--- a/integrations/claude-code/test/launch.test.mjs
+++ b/integrations/claude-code/test/launch.test.mjs
@@ -26,10 +26,11 @@ import { join } from 'node:path';
 
 import { PLUGIN_ROOT, REPO_ROOT, makeDataDir, makeProjectDir, tempDir, baseEnv, lib, mod } from './helpers/harness.mjs';
 
-/** §8.2 — the curated ten, in the guide's order. */
+/** §8.2 — the curated set, in the guide's order, with the three W2-1 promotions last. */
 const DEFAULT_ALLOWLIST = [
   'mubit_learned', 'mubit_recall', 'mubit_outcome', 'mubit_reflect', 'mubit_lessons',
   'mubit_diagnose', 'mubit_archive', 'mubit_dereference', 'mubit_forget', 'mubit_status',
+  'mubit_strategies', 'mubit_checkpoint', 'mubit_memory_health',
 ];
 
 // ---------------------------------------------------------------------------
@@ -233,15 +234,15 @@ test('per-conversation falls back to per-directory and says so on stderr', async
 // §8.2 — the allowlist the launcher hands to the server
 // ---------------------------------------------------------------------------
 
-// §8.2 — blank config means the curated ten, not "all 21". The whole point of the
+// §8.2 — blank config means the curated set, not "all 21". The whole point of the
 // allowlist is bounding the always-loaded context cost of the tool schemas (§3.5).
-test('MUBIT_MCP_TOOLS defaults to the curated ten when mcpTools is blank', async () => {
+test('MUBIT_MCP_TOOLS defaults to the curated set when mcpTools is blank', async () => {
   const r = await runLauncher({ extra: { MUBIT_MCP_TOOLS: '', CLAUDE_PLUGIN_OPTION_MCP_TOOLS: '' } });
   assert.ok(r.importedServer, `the launcher never imported ./server.js. stderr:\n${r.stderr}`);
 
   const got = String(r.envAtImport.MUBIT_MCP_TOOLS ?? '').split(',').map((s) => s.trim()).filter(Boolean);
   assert.deepEqual([...got].sort(), [...DEFAULT_ALLOWLIST].sort(),
-    `MUBIT_MCP_TOOLS must default to the curated ten (§8.2), got: ${got.join(', ') || '(empty)'}`);
+    `MUBIT_MCP_TOOLS must default to the curated ${DEFAULT_ALLOWLIST.length} (§8.2), got: ${got.join(', ') || '(empty)'}`);
 });
 
 // §8.2 — "Users restore any of them with mcpTools / MUBIT_MCP_TOOLS." A user-supplied
@@ -313,11 +314,12 @@ test('[mirror of @mubit-ai/mcp tools suite] a two-name allowlist registers exact
   assert.deepEqual(got, ['mubit_recall', 'mubit_status'], 'a two-name allowlist must register exactly those two');
 });
 
-// §8.2 — and the curated ten must select ten of the twenty-one.
-test('[mirror of @mubit-ai/mcp tools suite] the curated default allowlist selects ten of twenty-one', () => {
+// §8.2 — and the curated set must select exactly itself out of the twenty-one.
+test('[mirror of @mubit-ai/mcp tools suite] the curated default allowlist selects thirteen of twenty-one', () => {
   const names = realToolNames();
   const got = applyAllowlist(names, DEFAULT_ALLOWLIST.join(','));
-  assert.equal(got.length, 10, `curated allowlist selected ${got.length} tools: ${got.join(', ')}`);
+  assert.equal(got.length, DEFAULT_ALLOWLIST.length,
+    `curated allowlist selected ${got.length} tools: ${got.join(', ')}`);
   for (const n of DEFAULT_ALLOWLIST) {
     assert.ok(names.includes(n), `default allowlist names "${n}", which the bundled server does not register`);
   }
@@ -354,11 +356,11 @@ test('the bundled server honours the allowlist, and context-cost.json says so', 
     + '`node scripts/measure-context-cost.mjs --write`.');
 
   // `surface.registered` is the real `tools/list` answer, so under a blank `mcpTools` it is
-  // the curated ten — not the 21 the bundle *defines*. Both facts are checked, because
-  // "advertises ten" and "still carries all 21 for users who restore them" are separate
+  // the curated set — not the 21 the bundle *defines*. Both facts are checked, because
+  // "advertises the curated set" and "still carries all 21 for users who restore them" are separate
   // promises and only the first one bounds the context cost.
   assert.deepEqual(cost.surface?.registered, [...DEFAULT_ALLOWLIST].sort(),
-    'context-cost.json was measured against a tool surface that is not the curated ten — '
+    'context-cost.json was measured against a tool surface that is not the curated set — '
     + 're-measure with `node scripts/measure-context-cost.mjs --write`');
 
   for (const name of cost.surface?.registered ?? []) {

--- a/integrations/claude-code/test/manifests.test.mjs
+++ b/integrations/claude-code/test/manifests.test.mjs
@@ -43,10 +43,11 @@ const P = {
 /** The plugin's own MCP server prefix. `.mcp.json` names the server `mubit` (§3.3). */
 const QUALIFIED_PREFIX = 'mcp__plugin_mubit-memory_mubit__';
 
-/** §8.2 — ten of the twenty-one tools. */
+/** §8.2 — thirteen of the twenty-one tools; the last three were promoted in W2-1. */
 const DEFAULT_ALLOWLIST = [
   'mubit_learned', 'mubit_recall', 'mubit_outcome', 'mubit_reflect', 'mubit_lessons',
   'mubit_diagnose', 'mubit_archive', 'mubit_dereference', 'mubit_forget', 'mubit_status',
+  'mubit_strategies', 'mubit_checkpoint', 'mubit_memory_health',
 ];
 
 /** §6.2 — every key the plugin promises to honour at enable time. */
@@ -635,7 +636,7 @@ test('every tool in the default allowlist exists in the bundled MCP server', () 
     assert.ok(real.includes(name),
       `default allowlist names "${name}", which the bundled server does not register. Real tools: ${real.join(', ')}`);
   }
-  assert.equal(DEFAULT_ALLOWLIST.length, 10, 'the curated default allowlist is ten of twenty-one (§8.2)');
+  assert.equal(DEFAULT_ALLOWLIST.length, 13, 'the curated default allowlist is thirteen of twenty-one (§8.2)');
 });
 
 // §12.7 — same check, one level down: a tool named in a skill must exist in the server.

--- a/integrations/claude-code/test/mcp-surface.test.mjs
+++ b/integrations/claude-code/test/mcp-surface.test.mjs
@@ -25,21 +25,32 @@ import { join } from 'node:path';
 
 import { mcpListTools, PLUGIN_ROOT } from './helpers/harness.mjs';
 
-/** §8.2 — the curated ten, in the guide's order. */
+/**
+ * §8.2 — the curated set, in the guide's order, with the three promoted verbs after it.
+ *
+ * The first ten are the original curation. `mubit_strategies`, `mubit_checkpoint` and
+ * `mubit_memory_health` were excluded on the theory that a hook already covered them, and
+ * for the first two that was never quite true: nothing in the plugin reads the pattern
+ * *across* lessons, and the only checkpoint anyone gets is the involuntary one at
+ * `PreCompact` — a user cannot name a marker before doing something risky. The third was
+ * excluded while `skills/doctor/SKILL.md` was telling its reader to POST the same route by
+ * hand. Each now ships with a skill that makes it reachable.
+ */
 const DEFAULT_ALLOWLIST = [
   'mubit_learned', 'mubit_recall', 'mubit_outcome', 'mubit_reflect', 'mubit_lessons',
   'mubit_diagnose', 'mubit_archive', 'mubit_dereference', 'mubit_forget', 'mubit_status',
+  'mubit_strategies', 'mubit_checkpoint', 'mubit_memory_health',
 ];
 
 /**
- * The eleven §8.2 excludes: a hook already does the job better, or there is no Claude Code
+ * The eight §8.2 excludes: a hook already does the job better, or there is no Claude Code
  * surface for it at all. Named rather than derived, so this file states the contract
  * outright instead of restating whatever the server happens to register.
  */
 const EXCLUDED = [
-  'mubit_remember', 'mubit_context', 'mubit_checkpoint', 'mubit_memory_health',
+  'mubit_remember', 'mubit_context',
   'mubit_register_agent', 'mubit_list_agents', 'mubit_step_outcome', 'mubit_ingest_status',
-  'mubit_strategies', 'mubit_handoff', 'mubit_feedback',
+  'mubit_handoff', 'mubit_feedback',
 ];
 
 /** The remedy every failure in this file shares. Stated once. */
@@ -78,18 +89,18 @@ const RETRIEVAL = ['mubit_recall', 'mubit_lessons', 'mubit_diagnose', 'mubit_der
 let _default;
 const defaultSurface = () => (_default ??= mcpListTools());
 
-// §8.2 — a blank `mcpTools` means the curated ten. Not none, and not all 21.
-test('tools/list advertises exactly the curated ten', async () => {
+// §8.2 — a blank `mcpTools` means the curated set. Not none, and not all 21.
+test('tools/list advertises exactly the curated set', async () => {
   const { names } = await defaultSurface();
 
   assert.deepEqual(names, [...DEFAULT_ALLOWLIST].sort(),
-    `the server advertised ${names.length} tools, not the curated ten (§8.2).\n`
+    `the server advertised ${names.length} tools, not the curated ${DEFAULT_ALLOWLIST.length} (§8.2).\n`
     + `  advertised: ${names.join(', ')}${REMEDY}`);
 });
 
-// §3.5 — the cost of getting this wrong, stated as the thing it costs: eleven tool schemas
+// §3.5 — the cost of getting this wrong, stated as the thing it costs: eight tool schemas
 // resident in every session, forever, for verbs a hook already covers.
-test('none of the eleven excluded tools is advertised', async () => {
+test('none of the eight excluded tools is advertised', async () => {
   const { names } = await defaultSurface();
   const leaked = EXCLUDED.filter((n) => names.includes(n));
 
@@ -129,7 +140,7 @@ test('a user-supplied MUBIT_MCP_TOOLS is honoured verbatim', async () => {
 // §3.5 — `skills.test.mjs` already holds every SKILL.md to this bar: the description "is
 // what the model reads when deciding whether to invoke the skill; it is always loaded and
 // counts against contextCost, so it must actually describe the trigger". Tool descriptions
-// are the same surface with a higher bill — ten of them, resident in every request of every
+// are the same surface with a higher bill — every one of them resident in every request of every
 // session — and they were the one model-facing surface that never got the treatment: the
 // audit scored 0 of 21 carrying a trigger, mean length 91 characters, all of them endpoint
 // summaries. This asserts it on the artifact a user actually runs, not on the source, because
@@ -147,7 +158,7 @@ test('every advertised tool description says WHEN to use it', async () => {
     + `  confirm…" does not count: the trigger must be when/for/after/before/if.${PROSE_REMEDY}`);
 });
 
-// The curated ten overlap: four of them read memory, two of them write a lesson, two of them
+// The curated set overlaps: four of them read memory, two of them write a lesson, two of them
 // score one. A trigger alone still leaves the model choosing between near-synonyms, so each
 // must also say which neighbour to prefer or when calling it is wrong.
 test('every advertised tool description says which tool to prefer, or when not to call it', async () => {
@@ -157,7 +168,7 @@ test('every advertised tool description says which tool to prefer, or when not t
   assert.deepEqual(missing, [],
     `${missing.length} of ${tools.length} advertised descriptions carry no negative condition: `
     + `${missing.join(', ')}.\n`
-    + '  These ten are the entire surface a default install sees. Say which neighbour to prefer,\n'
+    + '  These are the entire surface a default install sees. Say which neighbour to prefer,\n'
     + '  or the case where this tool is the wrong one: "prefer …", "rather than …", "do not …",\n'
     + `  "never …".${PROSE_REMEDY}`);
 });
@@ -192,4 +203,72 @@ test('serverInfo reports the bundled server\'s real version', async () => {
     + 'ship in lockstep. The launcher inlines the version at build time (esbuild.config.mjs '
     + 'defines __MUBIT_MCP_VERSION__) and hands it over as MUBIT_MCP_VERSION — rebuild with '
     + '`npm run build`.');
+});
+
+// ---------------------------------------------------------------------------
+// §8.2 — the three verbs promoted into the allowlist
+// ---------------------------------------------------------------------------
+
+/** The W2-1 promotions: excluded until a skill existed to reach each of them. */
+const PROMOTED = ['mubit_strategies', 'mubit_checkpoint', 'mubit_memory_health'];
+
+/**
+ * The two description gates above, asserted on the promoted three by name.
+ *
+ * Those gates iterate whatever `tools/list` advertises, so once the launcher bundle is
+ * rebuilt they cover these anyway. That is exactly why this exists as well: a tool promoted
+ * into the default surface has to clear the bar *before* it starts costing every session, and
+ * a gate that only notices after the rebuild notices a session too late. The three
+ * descriptions were checked against the bundle when they were promoted and all three pass —
+ * this is the assertion, not the assumption.
+ *
+ * Launched with an explicit `MUBIT_MCP_TOOLS` rather than off `defaultSurface()`: the
+ * allowlist is honoured verbatim (asserted two tests up), so this reads the shipped
+ * descriptions whatever the committed launcher's compiled-in default happens to be.
+ */
+test('the three promoted tools describe when to use them, and what to prefer instead', async () => {
+  const { tools } = await mcpListTools({ extra: { MUBIT_MCP_TOOLS: PROMOTED.join(',') } });
+
+  assert.deepEqual(tools.map((t) => t.name).sort(), [...PROMOTED].sort(),
+    `the server did not advertise the promoted three: ${tools.map((t) => t.name).join(', ')}${REMEDY}`);
+
+  const noTrigger = tools.filter((t) => !TRIGGER.test(String(t.description ?? ''))).map((t) => t.name);
+  assert.deepEqual(noTrigger, [],
+    `${noTrigger.join(', ')} carry no usage trigger. These three were excluded from the default `
+    + 'surface until a skill existed to reach them; being advertised means every session now '
+    + `pays for their schemas, so each has to say when it is the right call.${PROSE_REMEDY}`);
+
+  const noNegative = tools.filter((t) => !NEGATIVE.test(String(t.description ?? ''))).map((t) => t.name);
+  assert.deepEqual(noNegative, [],
+    `${noNegative.join(', ')} carry no negative condition. Each of the three sits beside a near `
+    + 'neighbour it will be confused with — strategies with lessons, checkpoint with learned, '
+    + `memory_health with status — and only the description can settle it.${PROSE_REMEDY}`);
+});
+
+/**
+ * The neighbour each one is confused with, named in the description rather than merely
+ * implied — the same argument as the retrieval-four test above, for the same reason.
+ *
+ * `mubit_memory_health` is the sharpest case: it and `mubit_status` both answer "is memory
+ * working", one about the store and one about the connection, and the two have opposite
+ * fixes. A model that picks the wrong one reports a healthy connection to a user whose store
+ * is empty.
+ */
+test('each promoted tool names the neighbour it competes with', async () => {
+  const { tools } = await mcpListTools({ extra: { MUBIT_MCP_TOOLS: PROMOTED.join(',') } });
+  const byName = new Map(tools.map((t) => [t.name, String(t.description ?? '')]));
+
+  /** @type {Array<[string, string]>} */
+  const pairs = [
+    ['mubit_strategies', 'mubit_lessons'],
+    ['mubit_checkpoint', 'mubit_learned'],
+    ['mubit_memory_health', 'mubit_status'],
+  ];
+
+  const silent = pairs.filter(([name, neighbour]) => !(byName.get(name) ?? '').includes(neighbour));
+  assert.deepEqual(silent, [],
+    `${silent.map(([n, o]) => `${n} never names ${o}`).join('; ')}.\n`
+    + '  strategies is the pattern across lessons and mubit_lessons reads the individual ones;\n'
+    + '  a checkpoint is run state where mubit_learned is knowledge; memory_health inspects the\n'
+    + `  store where mubit_status inspects the connection.${PROSE_REMEDY}`);
 });

--- a/integrations/claude-code/test/skills.test.mjs
+++ b/integrations/claude-code/test/skills.test.mjs
@@ -39,8 +39,28 @@ const SERVER_BUNDLE = join(PLUGIN_ROOT, 'mcp', 'dist', 'server.js');
 /** §3.2 matcher note — `.mcp.json` names the server `mubit`. */
 const QUALIFIED_PREFIX = 'mcp__plugin_mubit-memory_mubit__';
 
-/** §2/§9 — the skills the plugin ships. `auth` is the seventh and `dashboard` the eighth. */
-const SKILLS = ['recall', 'remember', 'reflect', 'forget', 'doctor', 'setup', 'auth', 'dashboard'];
+/**
+ * §2/§9 — the skills the plugin ships, in the order they were added. The first eight are
+ * the original set; each of the rest grants one MCP tool that used to sit outside the
+ * default allowlist, because an allowlisted tool with nothing to invoke it is schema cost
+ * with no surface.
+ *
+ * One name per line on purpose: several branches append to this list, and a single-line
+ * array makes every one of those a conflict on the same line.
+ */
+const SKILLS = [
+  'recall',
+  'remember',
+  'reflect',
+  'forget',
+  'doctor',
+  'setup',
+  'auth',
+  'dashboard',
+  'strategies',
+  'checkpoint',
+  'memory-health',
+];
 
 /**
  * The two skills that call no MCP tool, and cannot.
@@ -124,8 +144,7 @@ function skillFile(name) {
 
 function loadSkill(name) {
   const text = readOrFail(skillFile(name), `skills/${name}/SKILL.md`,
-    'The plugin ships one skill each for recall, remember, reflect, forget, doctor, setup, auth '
-    + 'and dashboard.');
+    `The plugin ships one skill each for: ${SKILLS.join(', ')}.`);
   return parseFrontmatter(text, `skills/${name}/SKILL.md`);
 }
 
@@ -571,4 +590,55 @@ test('remember/SKILL.md names the setting that widens what an agent may write', 
   const { body } = loadSkill('remember');
   assert.match(body, /mcpLessonScope|MUBIT_MCP_LESSON_SCOPE/,
     'remember/SKILL.md does not name the setting that raises the scope ceiling (§6.2)');
+});
+
+// ---------------------------------------------------------------------------
+// §9 — the three skills that carry a promoted tool
+// ---------------------------------------------------------------------------
+
+/**
+ * Each of these three exists so that a tool promoted into the default allowlist has somewhere
+ * to be invoked from. That makes one sentence in each of them load-bearing: the sentence that
+ * separates the new tool from the neighbour it will otherwise be confused with. Without it the
+ * skill is a second, vaguer route to a tool the model already had, and the promotion has
+ * bought a schema in every session for nothing.
+ */
+
+// The tool's own description says it clusters lessons and to "prefer mubit_lessons to read the
+// individual lessons themselves". A skill that only says "finds patterns" sends the model here
+// for single-lesson questions, which is the one thing it answers badly.
+test('strategies/SKILL.md separates the pattern from the lessons it is a pattern over', () => {
+  const { body } = loadSkill('strategies');
+  assert.match(body, /across/i,
+    'strategies must say the answer is a pattern *across* lessons, not one of them (§9)');
+  assert.match(body, /mubit_lessons/,
+    'strategies must name mubit_lessons as the tool that reads the individual lessons — '
+    + 'the two are near-synonyms until one of them says so');
+});
+
+// `snapshot` is stored byte-for-byte with nothing extracting from it, so a model that writes a
+// headline has written a checkpoint that restores nothing.
+test('checkpoint/SKILL.md says the snapshot is stored verbatim, and is run state not knowledge', () => {
+  const { body } = loadSkill('checkpoint');
+  assert.match(body, /verbatim/i, 'checkpoint must say the snapshot is stored verbatim (§9)');
+  assert.match(body, /unsummaris|unsummariz|not summaris|not summariz/i,
+    'checkpoint must say nothing summarises it — a one-line snapshot restores nothing');
+  assert.match(body, /run state, not knowledge/i,
+    'checkpoint must draw the line in those words: a checkpoint is run state, not knowledge');
+  assert.match(body, /\/mubit-memory:remember/,
+    'checkpoint must send knowledge to /mubit-memory:remember, or the two writes get swapped '
+    + 'and memory fills with state that expires');
+});
+
+// The split this skill exists to state. Both tools fail as "memory is not working" and their
+// fixes are opposites: an empty store behind a healthy connection and a full store behind a
+// dead endpoint look identical from the status line.
+test('memory-health/SKILL.md states the store/connection split against mubit_status', () => {
+  const { body } = loadSkill('memory-health');
+  assert.match(body, /mubit_status/,
+    'memory-health must name mubit_status — it is the tool it will be confused with (§9)');
+  assert.match(body, /store/i, 'memory-health must say it inspects the store');
+  assert.match(body, /connection/i,
+    'memory-health must say mubit_status inspects the connection; without the second half the '
+    + 'first half is not a distinction');
 });

--- a/integrations/codex/README.md
+++ b/integrations/codex/README.md
@@ -149,7 +149,7 @@ asking how well attested a lesson is.
 
 ## Skills
 
-Seven, listed to the model as `mubit-memory:<name>`:
+Listed to the model as `mubit-memory:<name>`:
 
 | Skill | For |
 | --- | --- |
@@ -160,6 +160,9 @@ Seven, listed to the model as `mubit-memory:<name>`:
 | `reflect` | Extract lessons from this run now, rather than at session end. |
 | `forget` | Delete an entry, or down-weight one that is merely wrong. |
 | `doctor` | Diagnose. Its step 0 is the Codex-specific one: hooks that were never trusted. |
+| `strategies` | Read the pattern *across* many lessons rather than any single one. |
+| `checkpoint` | Save a named snapshot of where the run has got to, verbatim, before risky work. |
+| `memory-health` | Report what is actually stored: counts, staleness, contradictions. The store, not the connection. |
 
 There is no `mubit-recall` subagent here. Codex has no plugin-defined agent types — every
 `SubagentStart` reports `agent_type: "default"` — so a markdown subagent would be a file

--- a/integrations/codex/skills/checkpoint/SKILL.md
+++ b/integrations/codex/skills/checkpoint/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: checkpoint
+description: Save a named snapshot of where this run has got to, stored verbatim. Use when the user is about to do something risky or destructive, when a compaction is coming that they want to survive on their own terms, or when they ask to mark a point they may need to come back to.
+---
+
+Call `mcp__mubit__mubit_checkpoint` — `POST /v2/control/checkpoint` — with the state you are
+holding. `snapshot` is the only required argument; `label` is a short name the user can ask
+for later and is worth passing every time.
+
+## What goes in `snapshot`
+
+It is stored **verbatim and unsummarised**. Nothing rewrites it, shortens it or extracts
+anything from it, which cuts both ways: whatever you write is exactly what a future reader
+gets, and a one-line headline restores nothing.
+
+Write it for someone who has lost the conversation entirely — which is the only situation in
+which it will ever be read. What we were doing and why, what is finished, what is half-done
+and how far, the exact branch, file paths and commands in play, and the next concrete step.
+Prose is fine. Length is fine. This is the one write in the plugin where compressing is the
+mistake.
+
+## A checkpoint is run state, not knowledge
+
+This is the distinction that decides whether to use this skill at all.
+
+**Run state** is true now and false tomorrow: "mid-migration on `feat/x`, three files edited,
+two tests still red". It is worthless in six months and nobody wants it surfacing in an
+unrelated session. That is a checkpoint.
+
+**Knowledge** is true regardless of which run learned it: "a plugin-bundled `hooks.json` is
+inert under Codex", "this team wants small PRs". That is a lesson — save it with
+`mubit-memory:remember`, which classifies it and gives it a scope so it reaches later sessions
+on purpose.
+
+Getting this backwards costs something in both directions. A checkpoint used for knowledge
+buries a durable fact in a snapshot nobody will search for. A lesson used for run state turns
+memory into a session log, and every later recall pays for it.
+
+## When to call it
+
+The plugin registers a `PreCompact` hook that checkpoints on the way into a compaction. That
+is the automatic one, and it fires on the host's schedule — when the window fills — which is
+exactly the moment nobody can ask for. This tool is the half a person asks for: before a
+destructive migration, a history rewrite, a long refactor, or a point the user says they might
+want to walk back to.
+
+There is a Codex-specific reason not to rely on the automatic half. A plugin-bundled
+`hooks.json` is inert here: the registrations only take effect once they have been merged into
+`$CODEX_HOME/hooks.json` and trusted, which `mubit-memory:setup` walks through. On an install
+where that never happened, the `PreCompact` checkpoint has never fired and nothing says so.
+This tool reaches the instance over MCP rather than through a hook, so it works either way —
+and if the user is surprised there was no automatic checkpoint, that is the thing to check.
+
+Do not checkpoint reflexively or on a timer. Each call is a durable write, and a run littered
+with near-identical snapshots is harder to recover from than one with three good ones. The run
+is also shared with any Claude Code session in the same directory, so what you store here is
+what that session's reader finds too.

--- a/integrations/codex/skills/doctor/SKILL.md
+++ b/integrations/codex/skills/doctor/SKILL.md
@@ -104,8 +104,11 @@ the plugin moved.
 
 ## Step 3 — check memory health
 
-`POST /v2/control/memory_health {run_id}`. This is what distinguishes "nothing was ever
-written" from "things were written and are not coming back".
+`mcp__mubit__mubit_memory_health`, or `POST /v2/control/memory_health {run_id}` directly.
+This is what distinguishes "nothing was ever written" from "things were written and are not
+coming back". It inspects the store; step 2 inspected the connection, and a healthy answer
+there says nothing at all about this one. `mubit-memory:memory-health` is the same call with
+the reading guide attached.
 
 ## Step 4 — poll the run's ingest jobs
 

--- a/integrations/codex/skills/memory-health/SKILL.md
+++ b/integrations/codex/skills/memory-health/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: memory-health
+description: Report what is actually in Mubit memory — entry counts, staleness, contradictions and per-section health. Use when memory looks empty or stale and you need to know whether anything was ever stored, rather than whether the instance is reachable.
+---
+
+Call `mcp__mubit__mubit_memory_health` — `POST /v2/control/memory_health` — and report what it
+says about the store. `limit` (1 to 500) is how many entries it samples; the default is enough
+unless the user is specifically asking about an old part of a large run.
+
+## This inspects the store. `mcp__mubit__mubit_status` inspects the connection.
+
+The two answer different questions and are easy to confuse, because both fail as "memory
+isn't working".
+
+- **`mcp__mubit__mubit_status`** dials the instance. It tells you whether there is something
+  at the other end, whether the key is accepted, and which typed `ConnState` applies. It knows
+  nothing about what is stored.
+- **`mcp__mubit__mubit_memory_health`** asks what is in there: how many entries, how stale
+  they are, whether any of them contradict each other, and how each section is doing. It says
+  nothing about the connection — if the instance is unreachable this call does not answer at
+  all.
+
+So a healthy connection over an empty store and a full store behind a dead endpoint look
+identical from the outside, and they have opposite fixes. Answer the question the user
+actually asked before offering a remedy for the other one.
+
+## Reading the answer
+
+- **Zero entries, connection fine.** Nothing was ever written. Under Codex, check the hook
+  install first: a plugin-bundled `hooks.json` is inert until it has been merged into
+  `$CODEX_HOME/hooks.json` and trusted, and an untrusted hook is skipped silently under
+  `codex exec` — no prompt, no warning, exit 0. That is the local failure that produces a
+  reachable instance and an empty store. `mubit-memory:setup` walks the merge and the trust.
+- **Entries present, but recall keeps returning nothing.** The store is not the problem.
+  That is a retrieval or scope question: go to `mubit-memory:doctor` and read
+  `recall.empty_reason` from the local status marker, which names the cause outright.
+- **Contradictions.** Two stored lessons that disagree. Neither is automatically wrong and
+  deleting both loses the argument: prefer a negative `mcp__mubit__mubit_outcome` on the one
+  that turned out false, or `mubit-memory:forget` if it should never have existed. Report the
+  pair to the user rather than picking a winner yourself.
+- **Staleness.** Old is not broken. Say so — a lesson that has not been touched in months is
+  usually one that has not been contradicted either.
+
+`session_id` and `user_id` are best left out: the launcher already passes this run's id, and
+`user_id` is a retrieval filter, so supplying a value nothing was captured under reports an
+empty store that is not empty. The run itself is shared with any Claude Code session in the
+same directory, so the counts here cover both harnesses' work.
+
+Use `mubit-memory:doctor` when the complaint is vague — it walks the whole ladder, cheapest
+check first, and this call is one rung of it. Use this skill when the question is already
+narrowed to what memory contains. Do not poll it in a loop: it samples the store, and the
+answer does not change between turns.

--- a/integrations/codex/skills/strategies/SKILL.md
+++ b/integrations/codex/skills/strategies/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: strategies
+description: Surface the pattern across many stored lessons rather than any single one. Use when the user asks what memory has learned in general, why the same class of mistake keeps recurring, or how this project tends to work — not when they have one specific question.
+---
+
+Call `mcp__mubit__mubit_strategies` — `POST /v2/control/strategies` — and report the
+strategies it returns in the user's own terms: what the pattern is, and what it was inferred
+from. Ask for a small number and report all of them; a wall of generalisations is less useful
+than three good ones.
+
+## The one thing to be clear about
+
+**`mcp__mubit__mubit_strategies` is the pattern *across* lessons.
+`mcp__mubit__mubit_lessons` reads the individual lessons themselves.**
+
+Every other retrieval tool here answers with entries. `mcp__mubit__mubit_recall` finds the
+lessons that match a question, `mcp__mubit__mubit_lessons` lists the catalogue,
+`mcp__mubit__mubit_diagnose` matches an error's shape, `mcp__mubit__mubit_dereference`
+fetches the one whose `reference_id` you already hold. This is the only one that answers with
+a *shape over* many of them: it clusters stored lessons into emergent strategies, so what
+comes back is a generalisation the server derived, not a record anybody wrote.
+
+That makes the choice easy in both directions. "Why do we keep breaking the build the same
+way?" and "what has this project learned about testing?" are strategy questions. "What did we
+decide about the recall budget?" is not — that has one answer, and `mcp__mubit__mubit_recall`
+finds it faster and quotes it. Do not reach for this tool to locate a single lesson; it will
+hand back a summary of a cluster the lesson happens to sit in.
+
+## Arguments
+
+- `max_strategies` — 1 to 50. Ask for five to ten. The value of the answer is that it is
+  short; fifty clusters over a few dozen lessons is the same information with the pattern
+  taken back out.
+- `lesson_types` — narrows which lessons get clustered, when the user is asking about one
+  kind of thing ("what have we learned about failures?").
+- `session_id` and `user_id` — leave both out. The launcher already passes this run's id, and
+  `user_id` is a retrieval *filter* rather than a label: a value nothing was captured under
+  matches nothing, so inventing one is how you get an empty answer from a full store.
+
+Under Codex the run is shared. A Codex session and a Claude Code session in the same directory
+map to one run by design, so the lessons being clustered here are both harnesses' work. That
+is the intent, and it is worth saying when a pattern surfaces that this session did not
+produce.
+
+## Reporting it
+
+A strategy is inferred, not stated. It has less standing than a `rule`, which somebody wrote
+down on purpose and which is enforced as written. Say which you are relaying — presenting a
+clustered generalisation as though the user had asked for it is how a plausible pattern
+becomes a fact nobody agreed to.
+
+An empty or thin answer is usually not a fault. Clustering needs a body of lessons to cluster,
+and a young run does not have one yet. Before reporting that memory has no patterns, check
+that it has anything at all: `mubit-memory:memory-health` distinguishes "nothing was ever
+stored" from "stored, and there is genuinely no pattern in it".

--- a/integrations/codex/test/codex-manifests.test.mjs
+++ b/integrations/codex/test/codex-manifests.test.mjs
@@ -46,8 +46,25 @@ const P = {
   ccPlugin: join(SHARED_ROOT, '.claude-plugin', 'plugin.json'),
 };
 
-/** §2 — the seven skills, the same seven the Claude Code plugin ships. */
-const SKILLS = ['recall', 'remember', 'reflect', 'forget', 'doctor', 'setup', 'auth', 'dashboard'];
+/**
+ * §2 — the skills, the same set the Claude Code plugin ships.
+ *
+ * One name per line on purpose: several branches append to this list, and a single-line array
+ * makes every one of those a conflict on the same line.
+ */
+const SKILLS = [
+  'recall',
+  'remember',
+  'reflect',
+  'forget',
+  'doctor',
+  'setup',
+  'auth',
+  'dashboard',
+  'strategies',
+  'checkpoint',
+  'memory-health',
+];
 
 /** `.mcp.json` names the server `mubit`, so the model sees `mcp__mubit__<tool>`. */
 const MCP_SERVER = 'mubit';
@@ -407,12 +424,12 @@ test('no agents/ directory ships, because Codex has no plugin-defined subagent t
 // Skills as files
 // ===========================================================================
 
-test('all eight skills are present, one directory each', () => {
+test('every skill is present, one directory each', () => {
   const dirs = existsSync(P.skills)
     ? readdirSync(P.skills, { withFileTypes: true }).filter((d) => d.isDirectory()).map((d) => d.name).sort()
     : [];
   assert.deepEqual(dirs, [...SKILLS].sort(),
-    'the Codex plugin ships the same eight skills as the Claude Code one. A missing skill is '
+    'the Codex plugin ships the same skills as the Claude Code one. A missing skill is '
     + 'a slash command that silently does not exist.');
   for (const s of SKILLS) {
     assert.ok(existsSync(join(P.skills, s, 'SKILL.md')),

--- a/integrations/codex/test/codex-mcp.test.mjs
+++ b/integrations/codex/test/codex-mcp.test.mjs
@@ -28,10 +28,19 @@ import {
   CODEX_ROOT, SHARED_ROOT, mcpListTools, mcpDrive, fakeMubit, makeDataDir,
 } from './helpers/codex-fixtures.mjs';
 
-/** §8.2 — the curated ten. A blank allowlist means these, never "none" and never all 21. */
+/**
+ * §8.2 — the curated set. A blank allowlist means these, never "none" and never all 21.
+ *
+ * The Claude Code plugin's `mcp/src/launch.mjs` is the single source of this list and both
+ * plugins bundle it, so a promotion there reaches Codex without anyone editing this tree.
+ * `mubit_strategies`, `mubit_checkpoint` and `mubit_memory_health` arrived that way, each with
+ * a skill of its own — which is the part that does not travel for free, since Codex has no
+ * `tools:` grant and the prose is the only place the qualified name appears.
+ */
 const DEFAULT_ALLOWLIST = [
   'mubit_archive', 'mubit_dereference', 'mubit_diagnose', 'mubit_forget', 'mubit_learned',
   'mubit_lessons', 'mubit_outcome', 'mubit_recall', 'mubit_reflect', 'mubit_status',
+  'mubit_strategies', 'mubit_checkpoint', 'mubit_memory_health',
 ].sort();
 
 const CODEX_SERVER = join(CODEX_ROOT, 'mcp', 'dist', 'server.js');
@@ -77,13 +86,13 @@ test('the launcher is this plugin`s own build, not a copy of the other one', () 
 // tools/list
 // ===========================================================================
 
-test('tools/list advertises exactly the curated ten', async () => {
+test('tools/list advertises exactly the curated set', async () => {
   const { names, server } = await mcpListTools();
-  // § The eleven excluded verbs are excluded because a hook already does the job better, not
+  // § The eight excluded verbs are excluded because a hook already does the job better, not
   //   because tools are off by default. Advertising all 21 spends the model's window on
   //   schemas for tools it has no surface to use.
   assert.deepEqual(names, DEFAULT_ALLOWLIST,
-    `the Codex plugin advertises ${names.length} tools, not the curated ten. Under Codex the `
+    `the Codex plugin advertises ${names.length} tools, not the curated ${DEFAULT_ALLOWLIST.length}. Under Codex the `
     + 'model sees each as `mcp__mubit__<name>`, and every skill in this plugin names them that '
     + `way.\n  got:      ${names.join(', ')}\n  expected: ${DEFAULT_ALLOWLIST.join(', ')}`);
   assert.ok(server?.name, 'the server did not identify itself in `initialize`.');

--- a/integrations/codex/test/codex-skills.test.mjs
+++ b/integrations/codex/test/codex-skills.test.mjs
@@ -1,6 +1,6 @@
 // @ts-check
 /**
- * The seven skills, as data.
+ * The skills, as data.
  *
  * Codex reads a skill's frontmatter for two fields and nothing else. There is no
  * `allowed-tools` anywhere in the 0.146.0 binary and no `tools:` grant — the string does not
@@ -27,7 +27,26 @@ import { join } from 'node:path';
 import { CODEX_ROOT, SHARED_ROOT } from './helpers/codex-fixtures.mjs';
 
 const SKILLS_DIR = join(CODEX_ROOT, 'skills');
-const SKILLS = ['recall', 'remember', 'reflect', 'forget', 'doctor', 'setup', 'auth', 'dashboard'];
+/**
+ * The skills this plugin ships, in the order they were added and in lockstep with the Claude
+ * Code tree — the last test in this file asserts the two sets are equal.
+ *
+ * One name per line on purpose: several branches append to this list, and a single-line array
+ * makes every one of those a conflict on the same line.
+ */
+const SKILLS = [
+  'recall',
+  'remember',
+  'reflect',
+  'forget',
+  'doctor',
+  'setup',
+  'auth',
+  'dashboard',
+  'strategies',
+  'checkpoint',
+  'memory-health',
+];
 
 /**
  * The two skills that call no MCP tool: `auth` runs `bin/auth.mjs` to get a key, and
@@ -42,10 +61,11 @@ const PREFIX = 'mcp__mubit__';
 /** The prefix the Claude Code plugin uses. Present here is a copy-paste that was never adjusted. */
 const CC_PREFIX = 'mcp__plugin_mubit-memory_mubit__';
 
-/** The ten tools the plugin allowlists by default. */
+/** The thirteen tools the plugin allowlists by default. */
 const TOOLS = [
   'mubit_learned', 'mubit_recall', 'mubit_outcome', 'mubit_reflect', 'mubit_lessons',
   'mubit_diagnose', 'mubit_archive', 'mubit_dereference', 'mubit_forget', 'mubit_status',
+  'mubit_strategies', 'mubit_checkpoint', 'mubit_memory_health',
 ];
 
 // ---------------------------------------------------------------------------
@@ -97,12 +117,12 @@ function fencedBlocks(raw) {
 // Frontmatter
 // ===========================================================================
 
-test('the eight skills are exactly the eight directories', () => {
+test('the skill set is exactly the skill directories', () => {
   const dirs = existsSync(SKILLS_DIR)
     ? readdirSync(SKILLS_DIR, { withFileTypes: true }).filter((d) => d.isDirectory()).map((d) => d.name).sort()
     : [];
   assert.deepEqual(dirs, [...SKILLS].sort(),
-    'the Codex plugin ships the same eight skills as the Claude Code one; a missing one is a '
+    'the Codex plugin ships the same skills as the Claude Code one; a missing one is a '
     + 'command the user types and nothing answers.');
 });
 
@@ -293,7 +313,7 @@ test('forget: refuses to delete without confirming first', () => {
 // Drift against the Claude Code skills
 // ===========================================================================
 
-test('the two plugins ship the same eight skill names', () => {
+test('the two plugins ship the same skill names', () => {
   const ccDirs = readdirSync(join(SHARED_ROOT, 'skills'), { withFileTypes: true })
     .filter((d) => d.isDirectory()).map((d) => d.name).sort();
   const codexDirs = readdirSync(SKILLS_DIR, { withFileTypes: true })
@@ -303,4 +323,55 @@ test('the two plugins ship the same eight skill names', () => {
   //   other is a gap somebody meant to fill and forgot.
   assert.deepEqual(codexDirs, ccDirs,
     'the skill sets have diverged. The files differ by host; the set should not.');
+});
+
+// ===========================================================================
+// The three skills that carry a promoted tool
+// ===========================================================================
+
+/**
+ * Each of these three exists so that a tool promoted into the default allowlist has somewhere
+ * to be invoked from, which makes one sentence in each of them load-bearing: the one that
+ * separates the new tool from the neighbour it will otherwise be confused with.
+ *
+ * The stake is higher here than next door. Under Claude Code the `tools:` grant narrows what
+ * the skill can reach; Codex has no grant at all, so the prose is the only thing standing
+ * between the model and the wrong tool.
+ */
+
+test('strategies: separates the pattern from the lessons it is a pattern over', () => {
+  const { body } = read('strategies');
+  // § The tool clusters lessons. Asked for one lesson it returns a summary of the cluster that
+  //   lesson sits in, which reads like an answer and is not one.
+  assert.match(body, /across/i,
+    'strategies must say the answer is a pattern *across* lessons, not one of them.');
+  assert.match(body, new RegExp(`${PREFIX}mubit_lessons`),
+    'strategies must name mcp__mubit__mubit_lessons as the tool that reads the individual '
+    + 'lessons. The two are near-synonyms until one of them says so.');
+});
+
+test('checkpoint: says the snapshot is stored verbatim, and is run state not knowledge', () => {
+  const { body } = read('checkpoint');
+  // § `snapshot` is stored byte-for-byte and nothing extracts from it, so a model that writes a
+  //   headline has written a checkpoint that restores nothing.
+  assert.match(body, /verbatim/i, 'checkpoint must say the snapshot is stored verbatim.');
+  assert.match(body, /unsummaris|unsummariz|not summaris|not summariz/i,
+    'checkpoint must say nothing summarises it — a one-line snapshot restores nothing.');
+  assert.match(body, /run state, not knowledge/i,
+    'checkpoint must draw the line in those words: a checkpoint is run state, not knowledge.');
+  assert.match(body, /mubit-memory:remember/,
+    'checkpoint must send knowledge to mubit-memory:remember. Swap the two writes and memory '
+    + 'fills with state that expired the same afternoon.');
+});
+
+test('memory-health: states the store/connection split against mubit_status', () => {
+  const { body } = read('memory-health');
+  // § Both tools fail as "memory is not working" and their fixes are opposites: an empty store
+  //   behind a healthy connection and a full store behind a dead endpoint look identical.
+  assert.match(body, new RegExp(`${PREFIX}mubit_status`),
+    'memory-health must name mcp__mubit__mubit_status — it is the tool it is confused with.');
+  assert.match(body, /store/i, 'memory-health must say it inspects the store.');
+  assert.match(body, /connection/i,
+    'memory-health must say mubit_status inspects the connection; without the second half the '
+    + 'first half is not a distinction.');
 });


### PR DESCRIPTION
`mcp/dist/server.js` registers 21 tools; the plugin advertised ten. The other eleven were curated out on one argument — a hook already does this better, or there is no Claude Code surface for it — and for three of them that argument had quietly expired.

**`mubit_checkpoint`** was the clearest case, because it was named in the launcher's own doc comment as a hook's job. It is not. `PreCompact` fires when the window fills, which is the one moment nobody can ask for; "save where we are before I try this" is a decision a person makes and there was no way to express it. The hook and the tool are the involuntary and the voluntary halves of one thing, not two paths to the same one. That comment is rewritten rather than deleted.

**`mubit_strategies`** reads the pattern *across* many lessons. Every retrieval verb already advertised reads individual ones — recall by topic, diagnose by error shape, lessons as a catalogue, dereference by id — so this was never a duplicated lane; it was a lane nobody opened.

**`mubit_memory_health`** was excluded while `skills/doctor/SKILL.md` step 3 told its reader to `POST /v2/control/memory_health` by hand. Withholding the tool never removed the need for the route. It only moved the call off the tool surface and into prose, where it cost the same tokens and could not be invoked. Step 3 now names the tool with the route beside it, the form steps 2 and 5 already used.

## The rule being applied

Each promotion ships with a skill, on both hosts. An allowlisted tool with nothing to invoke it is a schema in every session for a verb the model has no reason to reach for — which is the failure the curation exists to prevent, so a promotion without a surface would have been the same mistake in the other direction.

Each skill turns on the one sentence that separates its tool from the neighbour it will otherwise be confused with:

| Skill | The sentence |
| --- | --- |
| `strategies` | the pattern *across* lessons; `mubit_lessons` reads the individual ones |
| `checkpoint` | a checkpoint is **run state, not knowledge** — knowledge goes to `/mubit-memory:remember`; `snapshot` is stored verbatim and unsummarised |
| `memory-health` | this inspects the **store**; `mubit_status` inspects the **connection** |

All three are pinned by content guards in both suites. A skill that loses one of them is a second, vaguer route to a tool the model already had.

## Two things the ticket did not know

The list is restated in **nine** places, not seven. `scripts/measure-context-cost.mjs` carries its own copy — it reported the new 13-tool surface as "`mcpTools` is inert, every user pays for every tool" until it was updated, and would have stamped a `curatedValue` measured against the old ten. `integrations/codex/test/codex-manifests.test.mjs` carries a second copy of the skill set beside `codex-skills.test.mjs`. Both are now in step.

`integrations/codex/test/codex-mcp.test.mjs` also asserts the live surface, so the Codex plugin is a third place the allowlist is stated — and the reason the red set below is larger than one test.

## Red on this branch, and why

Every failure is the wave's deliberate stale-bundle trade. Nothing here commits a bundle.

- `test/dist-freshness.test.mjs`, `integrations/codex/test/codex-dist.test.mjs` (x2, one per plugin) — `lib/config.mjs` and `mcp/src/launch.mjs` are bundled source.
- `codex-dist.test.mjs` "a source edit is actually caught by this gate" — a meta-test that mutates one built file and asserts exactly one difference. More than one legitimately differs now.
- `test/mcp-surface.test.mjs` and `codex-mcp.test.mjs` "tools/list advertises exactly the curated set" — **these two are new to the red set.** Both speak real stdio to the *committed* `mcp/dist/index.js`, so the allowlist they read is the one compiled into the shipped launcher, not this source. They cannot go green without the rebuild.

A local `MUBIT_CC_BUILD_SKIP_SERVER=1 npm run build` in both trees takes all of them green — **1245/1245** and **338/338** — and the bundles were reverted before commit. `md5 mcp/dist/server.js` is unchanged at `8295edfe6ca4207f603712db95552e39`.

## Generated files that are committed, deliberately

`scripts/context-cost.json` and `.claude-plugin/marketplace.json`, re-measured with `node scripts/measure-context-cost.mjs --write` against a temporarily rebuilt launcher, never hand-edited. **3725 → 4564 tokens**: 13 tool schemas (3515) and 11 skills (631). This branch is the only one changing the allowlist, so the alternative was leaving `launch.test.mjs` and `verify-manifests.mjs` red for the wave.

## Merge notes for the other three branches

Both skill arrays plus the codex-manifests one are now **one name per line**, in the agreed wave order (`… dashboard, strategies, checkpoint, memory-health`), so the branches appending `activity` and `pin` conflict on a line each rather than all on the same one. Test titles and assertion messages that hard-coded "eight" are count-free now, for the same reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0144iBiKzMKGEbg4WWk8r9zQ
