### PR TITLE
feat(claude-code): the audit question, and the one place it can be answered dishonestly

### DIFF
--- a/integrations/claude-code/README.md
+++ b/integrations/claude-code/README.md
@@ -111,7 +111,7 @@ one per `if` pattern.)
 Every hook exits 0, always. A memory layer has no business breaking a prompt — a dead server,
 an unwritable data dir, or a corrupt state file costs you a memory, never a turn.
 
-### Eight skills and one subagent
+### Nine skills and one subagent
 
 | Command | Use it for |
 | --- | --- |
@@ -122,7 +122,8 @@ an unwritable data dir, or a corrupt state file costs you a memory, never a turn
 | `/mubit-memory:remember` | Save a durable lesson, rule, or standing preference. |
 | `/mubit-memory:reflect` | Extract lessons from this session mid-flight, rather than waiting for `SessionEnd`. |
 | `/mubit-memory:forget` | Delete a lesson, or down-weight one that is merely wrong. |
-| `/mubit-memory:dashboard` | Open a local page over everything above: browse and search lessons, see what recall cost per prompt, watch ingest health. Loopback only, and the one skill the model cannot invoke for you. |
+| `/mubit-memory:dashboard` | Open a local page over everything above: browse and search lessons, see what recall cost per prompt, watch ingest health. Loopback only, and one of the skills the model cannot invoke for you. |
+| `/mubit-memory:activity` | The audit question: what does this instance actually hold, filtered by time, type, agent or origin — and an export of the whole record as JSONL you can keep. Prints to stdout; writes a file only if you ask. Also not model-invocable. |
 | `@mubit-memory:mubit-recall` | Subagent: multi-angle memory search in an isolated context, returns a synthesis instead of raw evidence. |
 
 ### Ten MCP tools

--- a/integrations/claude-code/bin/activity.src.mjs
+++ b/integrations/claude-code/bin/activity.src.mjs
@@ -1,0 +1,523 @@
+// @ts-check
+/**
+ * `bin/activity.src.mjs` — what `/mubit-memory:activity` runs. Bundled to `bin/activity.mjs`.
+ *
+ * The question this answers is not "how is memory doing", which `doctor` already owns more
+ * cheaply. It is the audit one: *what does my instance actually hold, and can I take the
+ * answer somewhere else.* Until now the only surface over `/v2/control/activity` was three tabs
+ * in a browser, and there was none at all over the export route.
+ *
+ * ## stdout by default; `--out` is opt-in
+ *
+ * A CLI that prints composes. It pipes, it redirects, it goes into `less`, and — the part that
+ * matters here — it writes to nobody's disk, which resolves the consent question by not having
+ * one. Nothing about "show me my memory" implies "leave a copy of my memory in the filesystem".
+ *
+ * `--out` is therefore a deliberate act, and it is guarded three ways before anything is
+ * dialled:
+ *
+ *   - It refuses to overwrite. The most likely second run of this command is the same command,
+ *     and the file it would clobber is the artefact somebody kept.
+ *   - It refuses any path inside the plugin data directory. `pruneStale`'s TTL table names the
+ *     directories it sweeps and this would not be one of them, so an export there is an
+ *     unbounded copy of the instance's memory that lives forever and that nothing ever
+ *     mentions again.
+ *   - It warns — not refuses — when the destination is inside a git working tree that is not
+ *     ignoring it. Committing an export is a reasonable thing to do deliberately and a bad
+ *     thing to do by accident, and the difference is whether git is about to offer it up.
+ *
+ * And a failure writes nothing at all. A half-written export is worse than none: it is a file
+ * that looks like a record.
+ *
+ * ## The stream split
+ *
+ * **The payload owns stdout.** The summary goes to stderr — unless `--out` took the payload, in
+ * which case the summary *is* the output and takes stdout. That one rule is why
+ * `--export | jq` works, and why `--export --out audit.jsonl` prints something a person can
+ * read instead of nothing.
+ *
+ * ## Why `pickRun` is here and not in `lib/runid.mjs`
+ *
+ * Because it is twenty lines, and because `lib/runid.mjs` is a subtle file that several
+ * branches are working in at once. Duplicating a small function is cheaper than resolving a
+ * conflict inside `resolveRunId`, and the extraction is easy once there is more than one copy
+ * to extract *from*. Duplicate small, extract after.
+ */
+
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
+import { dirname, isAbsolute, join, resolve, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { exportActivity, listActivity, scanActivity, scrubKey } from '../lib/activity.mjs';
+import { loadConfig } from '../lib/config.mjs';
+import { resolveDataDir } from '../lib/state.mjs';
+
+const USAGE = `mubit-memory: what this instance holds, and a copy of it you can keep.
+
+  node bin/activity.mjs [options]
+
+Modes
+  (default)            list the newest activity for one run, one page
+  --scan               page through everything that matches, oldest first
+  --export             ask the instance for its own export, verbatim
+
+Scope
+  --run <id>           a run id; the default is the newest run in the data dir
+  --all-runs           every run this key can see (listing and --scan only)
+  --type <t>           entry type filter; repeat for more than one
+  --since <rfc3339>    inclusive lower bound on created_at
+  --until <rfc3339>    inclusive upper bound on created_at
+  --agent <id>         one agent
+  --user <id>          one logical user
+
+Shape
+  --exclude-derived    drop entries the instance derived for itself, and verify it did
+  --full               every field, untruncated (the default is five keys)
+  --limit <n>          page size, 1..500
+  --max <n>            stop a --scan after n entries
+
+Output
+  (default)            a table on stdout, a summary on stderr
+  --jsonl              one JSON object per entry on stdout
+  --json               one JSON envelope on stdout
+  --out <path>         write the payload to a file; refuses to overwrite
+  -h, --help
+`;
+
+/** Flags that take a value. Named so a missing value is an error rather than a silent skip. */
+const VALUED = new Set(['--run', '--type', '--since', '--until', '--agent', '--user', '--limit', '--max', '--out']);
+
+/** Flags that do not. */
+const BARE = new Set([
+  '--scan', '--export', '--all-runs', '--exclude-derived', '--full', '--jsonl', '--json',
+  '--help', '-h',
+]);
+
+// ---------------------------------------------------------------------------
+// Arguments
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse argv into an intent, or into an error.
+ *
+ * A mistyped flag is the one input where guessing costs more than refusing:
+ * `--exclude-derive` quietly ignored produces a listing that claims to be filtered and is not,
+ * which is the whole class of failure this command was written against. So anything unknown,
+ * and any valued flag with nothing after it, is a refusal.
+ *
+ * @param {string[]} argv
+ * @returns {Record<string, any>}
+ */
+export function parseArgs(argv = []) {
+  /** @type {Record<string, any>} */
+  const out = {
+    mode: 'list', run: '', allRuns: false, entryTypes: [], since: '', until: '',
+    agent: '', user: '', excludeDerived: false, full: false, limit: 0, max: 0,
+    jsonl: false, json: false, out: '', help: false, error: '',
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const a = String(argv[i]);
+    if (VALUED.has(a)) {
+      const v = argv[i + 1];
+      if (v === undefined || String(v).startsWith('--')) {
+        out.error = `${a} needs a value`;
+        return out;
+      }
+      i += 1;
+      if (a === '--run') out.run = String(v).trim();
+      else if (a === '--type') out.entryTypes.push(String(v).trim());
+      else if (a === '--since') out.since = String(v).trim();
+      else if (a === '--until') out.until = String(v).trim();
+      else if (a === '--agent') out.agent = String(v).trim();
+      else if (a === '--user') out.user = String(v).trim();
+      else if (a === '--limit') out.limit = Number(v);
+      else if (a === '--max') out.max = Number(v);
+      else if (a === '--out') out.out = String(v);
+      continue;
+    }
+    if (!BARE.has(a)) {
+      out.error = `unknown flag: ${a}`;
+      return out;
+    }
+    if (a === '--scan') out.mode = 'scan';
+    else if (a === '--export') out.mode = 'export';
+    else if (a === '--all-runs') out.allRuns = true;
+    else if (a === '--exclude-derived') out.excludeDerived = true;
+    else if (a === '--full') out.full = true;
+    else if (a === '--jsonl') out.jsonl = true;
+    else if (a === '--json') out.json = true;
+    else out.help = true;
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// The run id
+// ---------------------------------------------------------------------------
+
+/**
+ * Which run this command is about.
+ *
+ * Runs are enumerated from `status/`, not `runs/`: the marker is the only file guaranteed to
+ * exist, because a session that recalled and never captured has no `runs/<id>/` at all.
+ * `health.json` lives in the same directory and is the endpoint probe cache, not a run.
+ *
+ * Newest wins, by the marker's own `updated_at` — and **a tie goes to the higher `-c<n>`**.
+ * After a `/clear` the run is `cc-<slug>-<hash>-c1` while the pre-clear marker is still on disk
+ * under its twelve-hour TTL, and both can be stamped inside the same millisecond. A resolver
+ * that ignores the counter answers with the run the user just cleared and reports its activity
+ * as this session's.
+ *
+ * @param {string} dataDir
+ * @param {string} [explicit]
+ * @returns {string}
+ */
+export function pickRun(dataDir, explicit = '') {
+  const want = typeof explicit === 'string' ? explicit.trim() : '';
+  if (want) return want;
+  try {
+    const dir = join(dataDir, 'status');
+    let best = '';
+    let bestAt = -1;
+    let bestClear = -1;
+    for (const file of readdirSync(dir)) {
+      if (!file.endsWith('.json') || file === 'health.json') continue;
+      const runId = file.slice(0, -5);
+      const path = join(dir, file);
+      let at = 0;
+      try {
+        const m = JSON.parse(readFileSync(path, 'utf8'));
+        at = Number(m && m.updated_at);
+      } catch { /* a marker truncated by a SIGKILL still names a run */ }
+      if (!Number.isFinite(at) || at <= 0) {
+        try { at = statSync(path).mtimeMs; } catch { at = 0; }
+      }
+      const clear = Number(/-c(\d+)$/.exec(runId)?.[1] ?? 0);
+      if (at > bestAt || (at === bestAt && clear > bestClear)) {
+        best = runId; bestAt = at; bestClear = clear;
+      }
+    }
+    return best;
+  } catch {
+    return '';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// --out
+// ---------------------------------------------------------------------------
+
+/**
+ * Whether this path may be written, decided before anything is dialled.
+ *
+ * @param {string} dest
+ * @param {string} dataDir
+ * @returns {{ok: boolean, abs: string, error: string}}
+ */
+export function checkOutPath(dest, dataDir) {
+  const abs = isAbsolute(dest) ? resolve(dest) : resolve(process.cwd(), dest);
+
+  if (existsSync(abs)) {
+    return { ok: false, abs, error: `${abs} already exists; refusing to overwrite it` };
+  }
+
+  const root = resolve(dataDir || '');
+  if (root && (abs === root || abs.startsWith(root + sep))) {
+    return {
+      ok: false,
+      abs,
+      error: `${abs} is inside the plugin data dir (${root}). An export there is an unbounded `
+        + 'copy of your memory outside the TTL sweep: nothing would ever prune it and nothing '
+        + 'would ever mention it again. Write it somewhere you will look.',
+    };
+  }
+
+  return { ok: true, abs, error: '' };
+}
+
+/**
+ * `''`, or the sentence to say about where this file landed.
+ *
+ * Best effort in every direction: no git, no repo, or a git that refuses to answer all mean
+ * silence rather than a wrong warning.
+ *
+ * @param {string} abs
+ * @returns {string}
+ */
+function gitNote(abs) {
+  try {
+    const cwd = dirname(abs);
+    const inside = spawnSync('git', ['rev-parse', '--is-inside-work-tree'],
+      { cwd, encoding: 'utf8', timeout: 2000 });
+    if (inside.status !== 0 || String(inside.stdout).trim() !== 'true') return '';
+    const ignored = spawnSync('git', ['check-ignore', '-q', abs], { cwd, timeout: 2000 });
+    // `check-ignore -q` exits 0 when the path IS ignored, 1 when it is not.
+    if (ignored.status === 0) return '';
+    return `${abs} is inside a git working tree and is not ignored — an export is a copy of `
+      + 'everything your instance holds, so add it to .gitignore before you commit anything.';
+  } catch {
+    return '';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Rendering
+// ---------------------------------------------------------------------------
+
+/** One entry as a table row. Newlines collapse: a row that wraps is not a row. */
+function row(entry) {
+  const e = (entry && typeof entry === 'object') ? entry : {};
+  const at = String(e.created_at ?? '').padEnd(20);
+  const type = String(e.entry_type ?? '').padEnd(12);
+  const id = String(e.id ?? '').padEnd(38);
+  const content = String(e.content ?? '').replace(/\s*\n\s*/g, ' ');
+  return `${at} ${type} ${id} ${content}`;
+}
+
+/**
+ * The notes that are *findings* rather than decoration.
+ *
+ * Each of these says the answer is not what was asked for, which is the only thing about a
+ * compliance answer more important than the answer.
+ *
+ * @param {Record<string, any>} data
+ * @returns {string[]}
+ */
+function findings(data) {
+  const notes = [];
+  if (data.excludeDerivedFallbackUsed) {
+    const n = data.droppedDerived;
+    notes.push(`the instance did not honour exclude_derived: ${n} `
+      + `${n === 1 ? 'entry it returned was' : 'entries it returned were'} derived, and `
+      + `${n === 1 ? 'was' : 'were'} dropped here instead`);
+  }
+  if (data.projectionFallbackUsed) {
+    notes.push('the instance did not honour the compact projection; content was truncated '
+      + 'locally, so what you see is shorter than what it sent');
+  }
+  if (data.truncated) {
+    notes.push(`this answer is incomplete: the scan stopped at ${data.truncatedReason}. `
+      + 'It is a prefix of what the instance holds, not all of it.');
+  }
+  return notes;
+}
+
+// ---------------------------------------------------------------------------
+// main
+// ---------------------------------------------------------------------------
+
+/**
+ * @param {string[]} argv
+ * @param {Record<string, string|undefined>} env
+ * @param {{stdout?: (s: string) => void, stderr?: (s: string) => void}} [deps]
+ * @returns {Promise<number>} process exit code
+ */
+export async function main(argv = process.argv.slice(2), env = process.env, deps = {}) {
+  const stdout = deps.stdout ?? ((s) => process.stdout.write(s));
+  const stderr = deps.stderr ?? ((s) => process.stderr.write(s));
+
+  const args = parseArgs(argv);
+  if (args.error) {
+    stderr(`${args.error}\n\n${USAGE}`);
+    return 2;
+  }
+  if (args.help) {
+    stdout(USAGE);
+    return 0;
+  }
+
+  const cfg = loadConfig(env);
+  const dataDir = resolveDataDir(cfg);
+
+  // "Every run" is a legitimate question for a listing, which is bounded by `limit`. It is not
+  // one for an export: that route takes no limit, so scope is the only bound its response body
+  // has, and `dial()` reads the whole thing into one string.
+  if (args.mode === 'export' && args.allRuns) {
+    stderr('--all-runs cannot be combined with --export: the export route takes no limit, so a '
+      + 'run is the only bound on how much comes back. Export one run at a time, or use --scan, '
+      + 'which pages.\n');
+    return 2;
+  }
+
+  const run = args.allRuns ? '' : pickRun(dataDir, args.run);
+  if (!run && !args.allRuns) {
+    stderr('No run to look at: this data dir has no run marker yet. Pass --run <id>, or '
+      + `--all-runs to ask across every run this key can see. (data dir: ${dataDir})\n`);
+    return 1;
+  }
+
+  // Checked before the dial, so a refusal costs nobody a request — and so a refusal is never
+  // reported after the instance has already done the work.
+  let outPath = '';
+  if (args.out) {
+    const verdict = checkOutPath(args.out, dataDir);
+    if (!verdict.ok) { stderr(`${verdict.error}\n`); return 1; }
+    outPath = verdict.abs;
+  }
+
+  const shared = {
+    run,
+    allRuns: args.allRuns,
+    entryTypes: args.entryTypes,
+    createdAfter: args.since,
+    createdBefore: args.until,
+    userId: args.user,
+    agentId: args.agent,
+  };
+
+  const res = args.mode === 'export'
+    ? await exportActivity(cfg, shared)
+    : args.mode === 'scan'
+      ? await scanActivity(cfg, {
+        ...shared,
+        excludeDerived: args.excludeDerived,
+        projection: args.full ? 'full' : 'compact',
+        limit: args.limit || undefined,
+        maxEntries: args.max || undefined,
+      })
+      : await listActivity(cfg, {
+        ...shared,
+        excludeDerived: args.excludeDerived,
+        projection: args.full ? 'full' : 'compact',
+        limit: args.limit || undefined,
+      });
+
+  if (!res.ok) {
+    const message = scrubKey(cfg, String(res.message ?? ''));
+    stderr(args.json
+      ? `${JSON.stringify({ ok: false, mode: args.mode, run, code: res.code, message })}\n`
+      : `${message}\n`);
+    return 1;
+  }
+
+  return args.mode === 'export'
+    ? emitExport(res.data, { args, run, outPath, stdout, stderr })
+    : emitEntries(res.data, { args, run, outPath, stdout, stderr });
+}
+
+/**
+ * The export. `content` reaches the file or the terminal exactly as the instance sent it —
+ * this is the half of the command whose entire value is that nothing reshaped it.
+ */
+function emitExport(data, { args, run, outPath, stdout, stderr }) {
+  const summary = args.json
+    ? JSON.stringify({
+      ok: true,
+      mode: 'export',
+      run,
+      format: data.format,
+      requestedFormat: data.requestedFormat,
+      entryCount: data.entryCount,
+      lines: data.lines,
+      bytes: data.bytes,
+      path: outPath || null,
+    })
+    : outPath
+      ? `wrote ${outPath} — ${data.bytes} bytes, ${data.entryCount} entries, format ${data.format}`
+      : `${data.entryCount} entries · ${data.bytes} bytes · format ${data.format}`;
+
+  const notes = [];
+  if (data.format && data.format !== data.requestedFormat) {
+    notes.push(`the instance answered in ${data.format}, not the ${data.requestedFormat} that `
+      + 'was asked for — whatever reads this next should not assume JSONL');
+  }
+
+  if (outPath) {
+    const failed = write(outPath, data.content);
+    if (failed) { stderr(`${failed}\n`); return 1; }
+    const note = gitNote(outPath);
+    if (note) notes.push(note);
+    stdout(`${summary}\n`);
+  } else {
+    // The payload owns stdout; the summary steps aside so a pipe gets only the record.
+    stdout(data.content);
+    stderr(`${summary}\n`);
+  }
+  for (const n of notes) stderr(`note: ${n}\n`);
+  return 0;
+}
+
+/** A listing or a scan. */
+function emitEntries(data, { args, run, outPath, stdout, stderr }) {
+  const entries = Array.isArray(data.entries) ? data.entries : [];
+
+  const envelope = {
+    ok: true,
+    mode: args.mode,
+    run: run || '(all runs)',
+    allRuns: args.allRuns === true,
+    count: entries.length,
+    totalVisible: data.totalVisible ?? 0,
+    droppedDerived: data.droppedDerived ?? 0,
+    excludeDerivedFallbackUsed: data.excludeDerivedFallbackUsed === true,
+    projectionFallbackUsed: data.projectionFallbackUsed === true,
+    truncated: data.truncated === true,
+    truncatedReason: data.truncatedReason ?? '',
+    pages: data.pages ?? 1,
+    nextPageToken: data.nextPageToken ?? '',
+    entries,
+  };
+
+  const payload = args.json
+    ? JSON.stringify(envelope)
+    : args.jsonl
+      ? `${entries.map((e) => JSON.stringify(e)).join('\n')}\n`
+      : `${entries.map(row).join('\n')}\n`;
+
+  const summary = `run ${envelope.run} · ${entries.length} entries shown · `
+    + `${envelope.totalVisible} visible upstream`
+    + (envelope.pages > 1 ? ` · ${envelope.pages} pages` : '');
+
+  if (outPath) {
+    const failed = write(outPath, payload);
+    if (failed) { stderr(`${failed}\n`); return 1; }
+    stdout(`wrote ${outPath} — ${Buffer.byteLength(payload)} bytes, ${entries.length} entries\n`);
+    const note = gitNote(outPath);
+    if (note) stderr(`note: ${note}\n`);
+  } else {
+    stdout(payload);
+    if (!args.json) stderr(`${summary}\n`);
+  }
+  for (const n of findings(envelope)) stderr(`note: ${n}\n`);
+  return 0;
+}
+
+/**
+ * The write itself. Only ever reached with the whole payload already in hand, which is what
+ * makes "a failure writes no file" true rather than aspirational.
+ *
+ * `wx` is `O_CREAT | O_EXCL`: `checkOutPath` already refused an existing path, but that check
+ * and this write are two syscalls apart and the file can appear in between. Refusing at the
+ * kernel is the only version of "does not overwrite" that is actually a guarantee.
+ *
+ * @returns {string} `''`, or the sentence to print instead of a success line
+ */
+function write(abs, text) {
+  try {
+    mkdirSync(dirname(abs), { recursive: true });
+    writeFileSync(abs, text, { encoding: 'utf8', flag: 'wx' });
+    return '';
+  } catch (err) {
+    return `could not write ${abs}: ${err?.message ?? err}`;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+// Guarded the same way as `bin/auth.src.mjs`: the tests import this module and drive `main()`
+// with captured streams, so it must not run itself on import.
+const selfPath = fileURLToPath(import.meta.url);
+const entryPath = process.argv[1] ? resolve(process.argv[1]) : '';
+
+if (entryPath === selfPath) {
+  // A person is watching this one, so it is allowed to fail out loud — but a stack trace is
+  // never the right output, and the exit code carries the verdict.
+  process.exitCode = await main().catch((err) => {
+    process.stderr.write(`activity could not run: ${err?.message ?? err}\n`);
+    return 1;
+  });
+}

--- a/integrations/claude-code/esbuild.config.mjs
+++ b/integrations/claude-code/esbuild.config.mjs
@@ -170,6 +170,10 @@ const targets = [
     'statusline.launcher.mjs', 'bin/statusline.mjs',
   ),
   { entryPoints: ['bin/auth.src.mjs'], outfile: out('bin/auth.mjs'), ...shared },
+  // `/mubit-memory:activity` — the audit surface. No launcher, for the same reason as `auth`
+  // below: a person typed the command and is watching it, so a runtime-floor failure is
+  // reported by the shell rather than swallowed.
+  { entryPoints: ['bin/activity.src.mjs'], outfile: out('bin/activity.mjs'), ...shared },
   // No launcher, for the same reason `bin/auth.mjs` has none: launchers exist for the entries
   // the *host* execs on its own (`hooks.json`, `settings.json`), where a parse error on an old
   // Node would be silent. A skill-invoked script is run by a person who is watching, and the

--- a/integrations/claude-code/lib/activity.mjs
+++ b/integrations/claude-code/lib/activity.mjs
@@ -1,0 +1,529 @@
+// @ts-check
+/**
+ * `lib/activity.mjs` — the audit question: what does my instance actually hold, and can I
+ * take the answer somewhere else.
+ *
+ * The route pair this module wraps has been reachable from the plugin for a while and was
+ * only ever used sideways: `lib/dashboard-api.mjs`'s `fetchActivity()` calls
+ * `/v2/control/activity` to join a `created_at` onto a lesson. The export route, the six
+ * request fields that turn a feed into a query, and any surface outside the dashboard's
+ * browser UI did not exist. This is that surface.
+ *
+ * ## A module-local route constant, not `lib/http.mjs`'s `ROUTES`
+ *
+ * `ROUTES` is the frozen table of routes that have a typed wrapper, a `capFor()` entry and a
+ * hook caller. Export has none of the three: it is called from a CLI a person types, on a
+ * deadline no hook shares, and nothing about it belongs on the path a prompt waits for.
+ * `lib/dashboard-api.mjs` already set the precedent for the other kind with `EXTRA_ROUTES`,
+ * and `test/dashboard-api.test.mjs` pins it.
+ *
+ * ## The listing is distrusted; the export is not
+ *
+ * This is the asymmetry the whole module is shaped around, and it is forced by the wire.
+ *
+ * `exclude_derived` and `projection` are the two request fields whose *purpose* is the
+ * compliance answer. "I asked for non-derived entries" is a claim about a field in a request.
+ * "These are the non-derived entries" is a claim about the bytes on screen. If an instance
+ * ignores the flag and we print the result under an `--exclude-derived` heading, we have
+ * manufactured a false audit artefact — precisely the failure this module exists to remove.
+ * So both are re-applied here, client-side, and both corrections are reported:
+ * `excludeDerivedFallbackUsed` and `projectionFallbackUsed` exist because "the server did not
+ * honour this" is itself audit-relevant.
+ *
+ * `/v2/control/activity/export` takes neither field. `ExportActivityRequest` has exactly
+ * seven — `run_id`, `user_id`, `agent_id`, `entry_types`, `created_after`, `created_before`,
+ * `sort` — so there is nothing to distrust, and `content` is handed on **verbatim**: no
+ * re-parse, no re-serialise, no added newline. A compliance artefact the client reshaped is
+ * not a record of what the server holds.
+ *
+ * ## `{record: false}` on everything, at 20 s and 45 s
+ *
+ * `lib/http.mjs` tags an abort `abortedEarly` — and declines to record it — *only* when the
+ * caller's deadline is tighter than the 4000 ms default. Both deadlines here are looser, so
+ * without `{record: false}` a slow export records `not_responding`, and five of those inside
+ * the breaker's window opens the circuit: recall stops and the capture drain stops, because
+ * the user asked a question about their own data. The listing reuses the dashboard's
+ * `READ_ONLY`; the export gets its own, longer one.
+ *
+ * ## No re-redaction
+ *
+ * The dashboard scrubs what it renders because putting text into a web page is a different
+ * consent from sending it to your own instance. Here a person is asking their own instance,
+ * in their own terminal, what it holds — re-redacting would defeat the only question being
+ * asked. Errors are still `scrubKey`'d, because an upstream message can quote a request
+ * header.
+ *
+ * ## Two facts about the route that decide the request shape
+ *
+ * **The export has no `limit`.** `lib/http.mjs` caps *requests*; `dial()` reads the whole
+ * response text and parses it in one allocation. An empty `run_id` means "every run this key
+ * can see", so run scope is the only bound the response body has — which is why a run id is
+ * required here rather than defaulted.
+ *
+ * **`total_visible` is a filtered count, not a total.** The server counts the entries left
+ * after its own filters and before paging, out of a pool it caps while collecting. It
+ * therefore over-counts by exactly whatever our client-side re-filter dropped, which is why
+ * `droppedDerived` is reported next to it: only both numbers together reconcile.
+ *
+ * Discipline shared with the rest of `lib/`: zero dependencies, Node >= 20 built-ins only,
+ * and nothing here throws.
+ */
+
+import {
+  EXTRA_ROUTES, READ_ONLY, fail, fetchActivity, mapError, ok, scrubKey,
+} from './dashboard-api.mjs';
+import { request } from './http.mjs';
+
+/**
+ * The one route with no wrapper anywhere else. See the module header for why it is not in
+ * `lib/http.mjs`'s `ROUTES`; `EXTRA_ROUTES.activity` is imported rather than restated so the
+ * listing path stays a single spelling across both files.
+ */
+export const ACTIVITY_ROUTES = Object.freeze({
+  activity: EXTRA_ROUTES.activity,
+  export: '/v2/control/activity/export',
+});
+
+/**
+ * How long an export may take.
+ *
+ * A hook gets 4000 ms because it sits on a prompt's critical path. The dashboard gets 20 s
+ * because a page is rendering. An export is a scan of every entry in a run, serialised into
+ * one string, with no `limit` on the route to bound it — so it gets its own number, and that
+ * number is longer than both. Nobody is blocked on it but the person who typed the command.
+ */
+export const EXPORT_TIMEOUT_MS = 45000;
+
+/** @see the module header — an unrecorded call is what keeps an audit from opening the breaker. */
+export const EXPORT_OPTS = Object.freeze({ record: false, timeoutMs: EXPORT_TIMEOUT_MS });
+
+/** The only format the route emits, stated so a caller can notice when it did not. */
+export const EXPORT_FORMAT = 'jsonl';
+
+/**
+ * The compact projection, as five keys in reading order.
+ *
+ * The server's own `compact` keeps all sixteen fields of `ActivityEntry` and only truncates
+ * content and rewrites metadata — the right trade for a page render and the wrong one for a
+ * listing read in a terminal. These five answer the audit question in full: what is it, when
+ * did it arrive, which run wrote it, and what does it say. The other eleven are what `full`
+ * and the export are for.
+ */
+export const COMPACT_KEYS = Object.freeze(['id', 'created_at', 'entry_type', 'run_id', 'content']);
+
+/**
+ * Where the server truncates, so a client truncation is the same bytes rather than a second,
+ * differently-shaped one. The server appends `...` after 200 characters, making 203 the
+ * longest a compacted row can be — which is also how "the server ignored `projection`" is
+ * detected without guessing.
+ */
+export const COMPACT_CONTENT_CHARS = 200;
+
+/** The server clamps `limit` into this range, and clamps a zero *up to one*, not to a default. */
+export const PAGE_MIN = 1;
+export const PAGE_MAX = 500;
+export const PAGE_DEFAULT = 100;
+
+/** Three independent bounds on a scan. Each one reports rather than trimming quietly. */
+export const SCAN_MAX_ENTRIES = 5000;
+export const SCAN_MAX_PAGES = 200;
+export const SCAN_BUDGET_MS = 60000;
+
+/**
+ * The metadata keys that mean "the instance derived this, a client did not write it".
+ *
+ * The server's own `exclude_derived` checks two of them — `promotion` and `derived` — through
+ * `as_bool()`, so a stringified boolean slips past it, and so does `auto_promoted`, which is
+ * what recurrence promotion writes. Erring wide is the only safe direction: over-filtering
+ * shows a caller fewer entries than exist, which they can see; under-filtering prints a
+ * derived entry under a heading that says there are none, which they cannot.
+ */
+const DERIVED_KEYS = Object.freeze(['derived', 'promotion', 'promoted', 'auto_promoted']);
+
+// ---------------------------------------------------------------------------
+// Export
+// ---------------------------------------------------------------------------
+
+/**
+ * `POST /v2/control/activity/export`.
+ *
+ * The response is `{format, content, entry_count}` and `content` is JSONL: one serialised
+ * `ActivityEntry` per line, joined with `\n` and with no trailing newline. It crosses this
+ * function untouched.
+ *
+ * A zero-byte export is the one answer that must never be reported as success. "Your instance
+ * holds nothing for this run" and "the export route answered with a field we could not read"
+ * are the same empty file on disk and completely different facts, so an absent, empty or
+ * non-string `content` is a failure with a message that says which.
+ *
+ * @param {Record<string, any>} cfg
+ * @param {{run?: string, entryTypes?: string[], createdAfter?: string, createdBefore?: string,
+ *          userId?: string, agentId?: string, sort?: string}} [params]
+ * @returns {Promise<Record<string, any>>}
+ */
+export async function exportActivity(cfg, params = {}) {
+  const p = obj(params);
+  const run = str(p.run);
+  if (!run) {
+    return fail(400, 'bad_request',
+      'export requires a run id: the route takes no limit, and an empty run_id means every run '
+      + 'this key can see — which is an unbounded response read into one string');
+  }
+
+  const req = {
+    run_id: run,
+    // Not a field of `ExportActivityRequest`, and deliberately sent anyway: it is the format
+    // this caller will accept, and the response's own `format` is checked against it below.
+    // Everything the route genuinely cannot honour is absent instead — see `dropped` below.
+    format: EXPORT_FORMAT,
+    // Chronological. The offset-drift argument that forces `asc` on a scan does not apply to
+    // a single request, but a record of what happened reads in the order it happened.
+    sort: str(p.sort) === 'desc' ? 'desc' : 'asc',
+  };
+  if (Array.isArray(p.entryTypes) && p.entryTypes.length) req.entry_types = p.entryTypes.map(String);
+  if (str(p.createdAfter)) req.created_after = str(p.createdAfter);
+  if (str(p.createdBefore)) req.created_before = str(p.createdBefore);
+  if (str(p.userId)) req.user_id = str(p.userId);
+  if (str(p.agentId)) req.agent_id = str(p.agentId);
+
+  // `exclude_derived`, `projection`, `limit` and `page_token` are NOT sent. The handler
+  // deserialises with serde's default, which drops unknown keys without complaint — so a
+  // request carrying `exclude_derived` is a client believing it filtered, and believing it
+  // silently. That is the whole failure mode this module was written against.
+
+  const res = await request(cfg, 'POST', ACTIVITY_ROUTES.export, req, EXPORT_OPTS);
+  if (!res.ok) return mapError(cfg, res);
+
+  const body = obj(res.body);
+  const content = body.content;
+  if (typeof content !== 'string') {
+    return fail(503, 'upstream_unreachable',
+      `the export route answered with no usable content (got ${describe(content)}); `
+      + 'an empty file is not the same fact as an empty instance');
+  }
+  if (content === '') {
+    return fail(503, 'upstream_unreachable',
+      'the export route answered with empty content; refusing to report a zero-byte export as '
+      + 'success, because "nothing is stored" and "nothing came back" are different answers');
+  }
+
+  return ok({
+    content,
+    bytes: Buffer.byteLength(content, 'utf8'),
+    // What the instance said it produced, next to what we asked for. An instance answering
+    // `csv` has not produced the JSONL the caller is about to parse, and that should be
+    // visible rather than inferred from a parse failure three steps later.
+    format: String(body.format || ''),
+    requestedFormat: EXPORT_FORMAT,
+    entryCount: Number(body.entry_count) || 0,
+    // Line count of what actually arrived, so a caller can reconcile it against the count the
+    // server reported without re-splitting the payload themselves.
+    lines: content.split('\n').length,
+    run,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Listing
+// ---------------------------------------------------------------------------
+
+/**
+ * One page of `POST /v2/control/activity`, re-filtered and re-projected.
+ *
+ * `sort` defaults to `desc`: a single page is what somebody means by "what just happened",
+ * and that is the newest end. A scan does the opposite, for a reason `scanActivity` explains.
+ *
+ * A run id is required unless `allRuns` is passed. An instance-wide listing is a different
+ * question from "what does this run hold", and it should be asked out loud rather than
+ * reached by omission.
+ *
+ * @param {Record<string, any>} cfg
+ * @param {{run?: string, allRuns?: boolean, limit?: number, pageToken?: string,
+ *          entryTypes?: string[], createdAfter?: string, createdBefore?: string,
+ *          userId?: string, agentId?: string, excludeDerived?: boolean,
+ *          projection?: string, sort?: string}} [params]
+ * @returns {Promise<Record<string, any>>}
+ */
+export async function listActivity(cfg, params = {}) {
+  const p = obj(params);
+  const run = str(p.run);
+  if (!run && p.allRuns !== true) {
+    return fail(400, 'bad_request',
+      'activity requires a run id; pass allRuns to list across every run this key can see');
+  }
+
+  const res = await fetchActivity(cfg, {
+    run,
+    limit: clamp(p.limit, PAGE_MIN, PAGE_MAX, PAGE_DEFAULT),
+    pageToken: str(p.pageToken),
+    sort: str(p.sort) === 'asc' ? 'asc' : 'desc',
+    projection: str(p.projection) === 'full' ? 'full' : 'compact',
+    entryTypes: Array.isArray(p.entryTypes) ? p.entryTypes : undefined,
+    excludeDerived: p.excludeDerived === true,
+    createdAfter: str(p.createdAfter),
+    createdBefore: str(p.createdBefore),
+    userId: str(p.userId),
+    agentId: str(p.agentId),
+  });
+  if (!res.ok) return res;
+
+  const corrected = correct(res.data.entries, {
+    excludeDerived: p.excludeDerived === true,
+    compact: str(p.projection) !== 'full',
+  });
+
+  return ok({
+    ...corrected,
+    nextPageToken: res.data.nextPageToken,
+    // The server's count, over the server's filtering, before paging. It over-counts by
+    // `droppedDerived` whenever the re-filter had to do work.
+    totalVisible: res.data.totalVisible,
+  });
+}
+
+/**
+ * Every page matching a query, oldest first.
+ *
+ * **A scan sorts ascending and a listing does not**, because pagination here is offset-style:
+ * the token is a numeric offset into a set the server re-derives on every request. Under
+ * `desc`, a write landing mid-scan shifts every later offset by one — the next page re-reads a
+ * row already read, and the row pushed past the boundary is never read at all. Under `asc` new
+ * rows arrive past the offsets already consumed, and a scan can only ever miss what was
+ * written after it started.
+ *
+ * Three bounds, and each one *reports*: a short answer that says it is short is usable, and a
+ * short answer that looks complete is the false artefact again. The page-token guard is the
+ * fourth and is not a bound but a liveness check — an instance whose `next_page_token` never
+ * advances would otherwise turn this into an infinite request loop against the user's own
+ * server.
+ *
+ * @param {Record<string, any>} cfg
+ * @param {Record<string, any>} [params] as `listActivity`, plus
+ *   `{maxEntries, maxPages, budgetMs}`
+ * @returns {Promise<Record<string, any>>}
+ */
+export async function scanActivity(cfg, params = {}) {
+  const p = obj(params);
+  const maxEntries = clamp(p.maxEntries, 1, 1_000_000, SCAN_MAX_ENTRIES);
+  const maxPages = clamp(p.maxPages, 1, 10_000, SCAN_MAX_PAGES);
+  const budgetMs = clamp(p.budgetMs, 1, 3_600_000, SCAN_BUDGET_MS);
+  const started = Date.now();
+
+  /** @type {any[]} */
+  const entries = [];
+  /** @type {Set<string>} */
+  const seen = new Set();
+  let token = str(p.pageToken);
+  let pages = 0;
+  let totalVisible = 0;
+  let droppedDerived = 0;
+  let excludeDerivedFallbackUsed = false;
+  let projectionFallbackUsed = false;
+  let truncated = false;
+  let truncatedReason = '';
+
+  for (;;) {
+    if (seen.has(token)) { truncated = true; truncatedReason = 'page_token_repeated'; break; }
+    seen.add(token);
+
+    const page = await listActivity(cfg, { ...p, pageToken: token, sort: 'asc' });
+    // A page lost in the middle means the scan did not see everything. Returning what did
+    // arrive, shaped like a completed scan, is how a partial answer becomes a complete-looking
+    // one — which is the same lie as an unhonoured filter, told by omission.
+    if (!page.ok) return page;
+
+    pages += 1;
+    entries.push(...page.data.entries);
+    totalVisible = page.data.totalVisible;
+    droppedDerived += page.data.droppedDerived;
+    excludeDerivedFallbackUsed = excludeDerivedFallbackUsed || page.data.excludeDerivedFallbackUsed;
+    projectionFallbackUsed = projectionFallbackUsed || page.data.projectionFallbackUsed;
+
+    if (entries.length >= maxEntries) { truncated = true; truncatedReason = 'max_entries'; break; }
+    if (Date.now() - started >= budgetMs) { truncated = true; truncatedReason = 'budget'; break; }
+    if (pages >= maxPages) { truncated = true; truncatedReason = 'max_pages'; break; }
+
+    token = page.data.nextPageToken;
+    if (!token) break;
+  }
+
+  return ok({
+    entries,
+    pages,
+    totalVisible,
+    droppedDerived,
+    excludeDerivedFallbackUsed,
+    projectionFallbackUsed,
+    truncated,
+    truncatedReason,
+    elapsedMs: Date.now() - started,
+    nextPageToken: truncated ? token : '',
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Derived detection and the compact shape
+// ---------------------------------------------------------------------------
+
+/**
+ * Whether an entry is something the instance derived rather than something a client wrote.
+ *
+ * Wider than the server's own test by design — see `DERIVED_KEYS`. The flag is looked for both
+ * inside `metadata_json` and on the entry itself, because a shared helper is reached by
+ * callers who have already parsed the one and by wire shapes that carry the other.
+ *
+ * Never throws: this runs once per entry over an export-sized listing.
+ *
+ * @param {any} entry
+ * @returns {boolean}
+ */
+export function isDerived(entry) {
+  if (!entry || typeof entry !== 'object' || Array.isArray(entry)) return false;
+  for (const key of DERIVED_KEYS) {
+    if (truthy(/** @type {any} */ (entry)[key])) return true;
+  }
+  const meta = parseMetadata(/** @type {any} */ (entry).metadata_json ?? /** @type {any} */ (entry).metadata);
+  if (!meta) return false;
+  for (const key of DERIVED_KEYS) {
+    if (truthy(meta[key])) return true;
+  }
+  return false;
+}
+
+/**
+ * One entry, as the five keys in `COMPACT_KEYS`.
+ *
+ * A missing field becomes an empty string rather than an absent key: this is written out as
+ * JSONL, and a stream whose rows have different keys is not a table.
+ *
+ * @param {any} entry
+ * @returns {Record<string, string>}
+ */
+export function compactEntry(entry) {
+  const e = (entry && typeof entry === 'object' && !Array.isArray(entry)) ? entry : {};
+  const content = e.content === undefined || e.content === null ? '' : String(e.content);
+  return {
+    id: plain(e.id),
+    created_at: plain(e.created_at),
+    entry_type: plain(e.entry_type),
+    run_id: plain(e.run_id),
+    content: content.length > COMPACT_CONTENT_CHARS
+      ? `${content.slice(0, COMPACT_CONTENT_CHARS)}...`
+      : content,
+  };
+}
+
+/**
+ * Apply both client-side corrections to one page, and report which of them had to do work.
+ *
+ * The projection check is structural rather than a guess: a server-compacted row is at most
+ * `COMPACT_CONTENT_CHARS + 3` characters, so anything longer is proof the flag did not take
+ * effect. The derived check is simply "did anything survive the server's filter that should
+ * not have".
+ *
+ * @param {any[]} raw
+ * @param {{excludeDerived: boolean, compact: boolean}} o
+ */
+function correct(raw, o) {
+  let entries = Array.isArray(raw) ? raw : [];
+  let droppedDerived = 0;
+
+  if (o.excludeDerived) {
+    const kept = entries.filter((e) => !isDerived(e));
+    droppedDerived = entries.length - kept.length;
+    entries = kept;
+  }
+
+  let projectionFallbackUsed = false;
+  if (o.compact) {
+    projectionFallbackUsed = entries.some((e) => {
+      const c = e && typeof e === 'object' ? e.content : '';
+      return typeof c === 'string' && c.length > COMPACT_CONTENT_CHARS + 3;
+    });
+    entries = entries.map(compactEntry);
+  }
+
+  return {
+    entries,
+    droppedDerived,
+    excludeDerivedFallbackUsed: droppedDerived > 0,
+    projectionFallbackUsed,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Coercion
+// ---------------------------------------------------------------------------
+
+/**
+ * `metadata_json`, whatever shape it arrived in.
+ *
+ * The proto declares it a `string`, so on the wire it is JSON in a string. Callers that have
+ * already parsed it hand over an object, and instances that round-trip it through a second
+ * encoder hand over a JSON string whose contents are themselves JSON. Two unwraps cover all
+ * three; the bound is fixed rather than a loop so a pathological value cannot spin.
+ *
+ * @param {any} raw
+ * @returns {Record<string, any>|null}
+ */
+function parseMetadata(raw) {
+  let v = raw;
+  for (let i = 0; i < 2; i += 1) {
+    if (v && typeof v === 'object' && !Array.isArray(v)) return v;
+    if (typeof v !== 'string' || !v.trim()) return null;
+    try { v = JSON.parse(v); } catch { return null; }
+  }
+  return (v && typeof v === 'object' && !Array.isArray(v)) ? v : null;
+}
+
+/**
+ * The truth values a flag arrives as. A JSON boolean is what the server writes; the string
+ * spellings are what a metadata writer that stringified its booleans produces, and the server
+ * misses those because `as_bool()` rejects them.
+ * @param {any} v
+ */
+function truthy(v) {
+  if (v === true) return true;
+  if (typeof v === 'string') {
+    const s = v.trim().toLowerCase();
+    return s === 'true' || s === '1' || s === 'yes';
+  }
+  return false;
+}
+
+/** @param {any} v @returns {string} */
+function str(v) {
+  return typeof v === 'string' ? v.trim() : '';
+}
+
+/** Untrimmed: a listing shows what is stored, and trailing space is part of what is stored. */
+function plain(v) {
+  return v === undefined || v === null ? '' : String(v);
+}
+
+/** @param {any} v */
+function obj(v) {
+  return (v && typeof v === 'object' && !Array.isArray(v)) ? v : {};
+}
+
+/** @param {any} v @param {number} lo @param {number} hi @param {number} dflt */
+function clamp(v, lo, hi, dflt) {
+  const n = typeof v === 'number' ? v : Number(v);
+  if (!Number.isFinite(n)) return dflt;
+  return Math.min(hi, Math.max(lo, Math.trunc(n)));
+}
+
+/** A type name for an error message, without putting the value itself into one. */
+function describe(v) {
+  if (v === undefined) return 'no field at all';
+  if (v === null) return 'null';
+  if (Array.isArray(v)) return 'an array';
+  return `a ${typeof v}`;
+}
+
+/**
+ * Re-exported so a caller that only needs to scrub one string does not have to know that the
+ * dashboard owns the implementation. Nothing here returns `cfg`, and every message crossing
+ * the boundary has already been through it.
+ */
+export { scrubKey, READ_ONLY };

--- a/integrations/claude-code/lib/dashboard-api.mjs
+++ b/integrations/claude-code/lib/dashboard-api.mjs
@@ -284,9 +284,19 @@ async function createdAtIndex(cfg, run, lessonCount) {
  * clamps to 1 when it is 0**, so an omitted limit does not mean "the default", it means one
  * entry. The limit here is therefore always explicit.
  *
+ * The last five parameters are `ListActivityRequest` fields the dashboard never needed and
+ * `lib/activity.mjs` does. Every one of them is emitted **only when set**, which is not
+ * fastidiousness: an unconditional `user_id: ''` is read server-side by
+ * `effective_logical_user_scope` and becomes a retrieval filter nobody asked for — the same
+ * shape as the trap on the ingest side, where filling `user_id` made new captures
+ * unrecallable. `exclude_derived: false` is likewise absent rather than false, so a request
+ * body says only what the caller actually asked for.
+ *
  * @param {Record<string, any>} cfg
  * @param {{run?: string, limit?: number, pageToken?: string, projection?: string,
- *          entryTypes?: string[], sort?: string}} [params]
+ *          entryTypes?: string[], sort?: string, excludeDerived?: boolean,
+ *          createdAfter?: string, createdBefore?: string, userId?: string,
+ *          agentId?: string}} [params]
  * @returns {Promise<Record<string, any>>}
  */
 export async function fetchActivity(cfg, params = {}) {
@@ -302,6 +312,11 @@ export async function fetchActivity(cfg, params = {}) {
   if (Array.isArray(params.entryTypes) && params.entryTypes.length) {
     req.entry_types = params.entryTypes.map(String);
   }
+  if (params.excludeDerived === true) req.exclude_derived = true;
+  if (str(params.createdAfter)) req.created_after = str(params.createdAfter);
+  if (str(params.createdBefore)) req.created_before = str(params.createdBefore);
+  if (str(params.userId)) req.user_id = str(params.userId);
+  if (str(params.agentId)) req.agent_id = str(params.agentId);
 
   const res = await request(cfg, 'POST', EXTRA_ROUTES.activity, req, READ_ONLY);
   if (!res.ok) return mapError(cfg, res);

--- a/integrations/claude-code/skills/activity/SKILL.md
+++ b/integrations/claude-code/skills/activity/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: activity
+description: "Answer the audit question: list what this Mubit instance actually holds for a run, filter it by time, type, agent or origin, and export the whole record as JSONL you can keep. Read-only."
+disable-model-invocation: true
+allowed-tools: ["Bash(node ${CLAUDE_PLUGIN_ROOT}/bin/activity.mjs:*)"]
+---
+
+**This skill never installs anything, and it writes nothing anywhere unless asked.** It runs one
+Node process from the plugin directory, makes one or more read-only calls to the configured
+instance, and prints the answer.
+
+`disable-model-invocation: true` is deliberate, and matches `dashboard`. This is a question a
+person asks about their own data; nothing in a conversation should decide on its own to pull a
+copy of somebody's memory into the transcript. A disabled skill's description is not
+always-loaded context either, so it costs nothing until somebody types it.
+
+## The distinction that decides which command to run
+
+There are two things this command can produce and they are **not the same kind of answer**.
+
+- **A listing** is a claim *this client* makes. The plugin sends the filters, and then checks
+  the result against them itself: it re-drops derived entries and re-truncates content, and it
+  says so when it had to. A listing is for reading.
+- **An export** is the record *the instance holds*, byte for byte. `/v2/control/activity/export`
+  accepts no `exclude_derived` and no `projection` at all, so an export is never filtered and
+  never truncated, and nothing here reshapes it. An export is for keeping.
+
+**Never describe an export as "filtered activity".** If somebody asks for "an export of my
+non-derived lessons", they are asking for two different operations: an export is everything in
+scope, and the filtering they want is a listing. Say which one they got.
+
+## Reading it
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/bin/activity.mjs"
+node "${CLAUDE_PLUGIN_ROOT}/bin/activity.mjs" --exclude-derived --type lesson
+node "${CLAUDE_PLUGIN_ROOT}/bin/activity.mjs" --scan --since 2026-08-01T00:00:00Z
+```
+
+The default is one page of the newest activity for the newest run in this data directory.
+`--scan` pages through everything that matches, oldest first. `--run <id>` picks a run and
+`--all-runs` asks across every run the key can see.
+
+Filters: `--type` (repeatable), `--since` / `--until` as RFC3339, `--agent`, `--user`, and
+`--exclude-derived` for the entries the instance promoted for itself rather than ones a client
+wrote. `--full` returns every field untruncated; the default is five keys per entry.
+
+Output: a table by default, `--jsonl` for one object per line, `--json` for one envelope. The
+payload goes to stdout and the summary to stderr, so a pipe gets only the data.
+
+## Exporting it
+
+```bash
+node "${CLAUDE_PLUGIN_ROOT}/bin/activity.mjs" --export
+node "${CLAUDE_PLUGIN_ROOT}/bin/activity.mjs" --export --out ~/mubit-audit.jsonl
+```
+
+Without `--out` the JSONL goes to stdout, which is the whole point: it composes, and it leaves
+nothing on anybody's disk.
+
+**Do not pass `--out` unless the user asked for a file.** An export is a complete copy of what
+the instance holds for a run, and creating one is a decision that belongs to them, not to a
+turn that seemed like it might want one. When you do pass it, **name the absolute path in your
+reply** — the command prints it, and a file the user cannot find is a file they cannot delete.
+
+`--out` refuses to overwrite, and refuses any path inside the plugin data directory: an export
+there sits outside the TTL sweep, so it would live forever and nothing would ever mention it
+again. It warns when the destination is inside a git working tree that is not ignoring it.
+`--all-runs` is refused with `--export`, because that route takes no limit and a run is the
+only bound on how much comes back.
+
+## What to say about the numbers
+
+Three of the things this prints are **findings**, not decoration, and they are the reason the
+answer can be trusted. Relay them rather than summarising them away:
+
+1. **"the instance did not honour exclude_derived"** means derived entries came back under a
+   request that excluded them, and this client dropped them locally. The listing is correct;
+   the server's filter is not. That is worth telling the user, because it is the difference
+   between a filter and a claim about a filter.
+2. **"the instance did not honour the compact projection"** means content was truncated here
+   rather than upstream. Nothing was lost — `--full` or an export has all of it.
+3. **"this answer is incomplete"** on a `--scan` means it stopped at a bound (entry cap, wall
+   clock, or page count). It is a prefix, not the whole record. Say so; do not present it as a
+   complete answer, and do not quietly re-run with a bigger cap without saying why.
+
+`visible upstream` is the instance's own count of everything matching the filters it applied,
+before paging — so when the first finding fires, it is larger than the number of rows shown by
+exactly the number that were dropped here.
+
+## The one thing it cannot tell you
+
+Per-prompt recall cost and latency are not in the activity feed; they are local, under
+`runs/<run_id>/turns/`. `/mubit-memory:dashboard`'s **Turns** tab is where that lives, joined
+against the instance's side of the same session. Use this skill for what the instance holds and
+that tab for what each prompt cost.
+
+## Related
+
+- `/mubit-memory:dashboard` — the same data as a page, plus the local per-prompt series.
+- `/mubit-memory:doctor` — the cheaper question, and the right one when something is broken
+  rather than merely unknown.
+- `/mubit-memory:forget` — what to run when this listing turns up something that should not be
+  there.

--- a/integrations/claude-code/test/activity-cli.test.mjs
+++ b/integrations/claude-code/test/activity-cli.test.mjs
@@ -1,0 +1,446 @@
+// @ts-check
+/**
+ * `bin/activity.src.mjs` — the surface a person actually reaches the audit question through.
+ *
+ * The design decision this file exists to pin is **stdout by default, `--out` opt-in**. A CLI
+ * that prints composes: it pipes, it redirects, it goes into `less`, and it writes to nobody's
+ * disk — which resolves the consent question by not having one. `--out` is then a deliberate
+ * act, and it is guarded three ways: it refuses to overwrite, it refuses any path inside the
+ * plugin data directory (an export there is an unbounded copy sitting outside `pruneStale`'s
+ * TTL table, so it would live forever and nothing would ever mention it), and it says out loud
+ * when the file it just wrote is inside a git working tree that is not ignoring it.
+ *
+ * The second is that **a failure writes nothing**. A half-written export is worse than none:
+ * it is a file that looks like a record.
+ *
+ * No real network — every test drives `main()` against `fakeMubit`, capturing stdout and
+ * stderr rather than letting them reach the terminal.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { baseEnv, fakeMubit, makeDataDir, makeProjectDir, mod, tempDir } from './helpers/harness.mjs';
+
+const RUN = 'cc-here-00000001';
+const EXPORT_ROUTE = 'POST /v2/control/activity/export';
+const LIST_ROUTE = 'POST /v2/control/activity';
+
+function activityEntry(over = {}) {
+  return {
+    id: 'a3c1f0de-0000-4000-8000-000000000001',
+    run_id: RUN,
+    entry_type: 'trace',
+    content: 'ran the migration',
+    created_at: '2026-08-19T15:03:18Z',
+    metadata_json: '{}',
+    reference_id: 'ref_1',
+    ...over,
+  };
+}
+
+function listPage(entries, next = '', total = entries.length) {
+  return { json: { entries, next_page_token: next, total_visible: total } };
+}
+
+function exportBody(content) {
+  return { json: { format: 'jsonl', content, entry_count: content.split('\n').length } };
+}
+
+/** A marker for `<run>`, so the CLI's run resolver has something to find. */
+function marker(dataDir, runId, updatedAt) {
+  mkdirSync(join(dataDir, 'status'), { recursive: true });
+  writeFileSync(join(dataDir, 'status', `${runId}.json`),
+    JSON.stringify({ run_id: runId, state: 'ready', updated_at: updatedAt }));
+}
+
+/**
+ * A fake instance, an env pointed at it, and the CLI, with both streams captured.
+ *
+ * @param {import('node:test').TestContext} t
+ * @param {{routes?: Record<string, any>, dataDir?: string, extra?: Record<string, string>}} [o]
+ */
+async function cli(t, o = {}) {
+  const dataDir = o.dataDir ?? makeDataDir();
+  const server = await fakeMubit(o.routes ?? {});
+  t.after(() => server.close());
+  const env = baseEnv({ dataDir, endpoint: server.url, extra: o.extra });
+  const bin = await mod('bin/activity.src.mjs');
+
+  /** @type {string[]} */ const out = [];
+  /** @type {string[]} */ const err = [];
+  const run = (argv, over = {}) => bin.main(argv, { ...env, ...over }, {
+    stdout: (s) => out.push(s),
+    stderr: (s) => err.push(s),
+  });
+
+  return { dataDir, server, env, bin, run, out, err, stdout: () => out.join(''), stderr: () => err.join('') };
+}
+
+// ===========================================================================
+// Arguments
+// ===========================================================================
+
+// A typo in a flag is the one input where guessing is worse than refusing: `--exclude-derive`
+// silently ignored produces an export that claims to be filtered and is not.
+test('cli: an unknown flag exits 2 and dials nothing', async (t) => {
+  const { server, run, stderr } = await cli(t, { routes: { [LIST_ROUTE]: listPage([]) } });
+
+  for (const argv of [['--exclude-derive'], ['--nope'], ['-x'], ['--out'], ['--limit']]) {
+    assert.equal(await run(argv), 2, `${argv.join(' ')} must exit 2`);
+  }
+  assert.match(stderr(), /unknown|missing|usage/i);
+  server.assertNotCalled('POST', '/v2/control/activity');
+  server.assertNotCalled('POST', '/v2/control/activity/export');
+});
+
+test('cli: --help exits 0, prints usage, and dials nothing', async (t) => {
+  const { server, run, stdout } = await cli(t);
+  assert.equal(await run(['--help']), 0);
+  assert.match(stdout(), /--out/);
+  assert.match(stdout(), /--export/);
+  assert.equal(server.requests.length, 0);
+});
+
+// ===========================================================================
+// stdout by default
+// ===========================================================================
+
+/**
+ * The whole `--out` design in one assertion: without it, nothing anywhere on disk changes.
+ * The temp directory is checked as a whole rather than one expected path, because the failure
+ * being guarded against is a file appearing *somewhere*, not at a name we predicted.
+ */
+test('cli: with no --out, an export writes no file and prints to stdout', async (t) => {
+  const dataDir = makeDataDir();
+  const { run, stdout, stderr } = await cli(t, {
+    dataDir,
+    routes: { [EXPORT_ROUTE]: exportBody('{"id":"a"}\n{"id":"b"}') },
+  });
+  marker(dataDir, RUN, Date.now());
+
+  const code = await run(['--export']);
+  assert.equal(code, 0, stderr());
+  assert.equal(stdout(), '{"id":"a"}\n{"id":"b"}',
+    'the export content is the payload and owns stdout, byte for byte');
+  assert.match(stderr(), /2 entries/, 'the summary goes to stderr so the payload stays pipeable');
+
+  // Nothing new under the data dir but the config cache the CLI legitimately writes.
+  const strays = ['activity.jsonl', 'export.jsonl', 'out.jsonl']
+    .filter((n) => existsSync(join(dataDir, n)));
+  assert.deepEqual(strays, []);
+});
+
+test('cli: a listing prints its rows to stdout and its summary to stderr', async (t) => {
+  const dataDir = makeDataDir();
+  const { run, stdout, stderr } = await cli(t, {
+    dataDir,
+    routes: { [LIST_ROUTE]: listPage([activityEntry(), activityEntry({ id: 'b', content: 'second' })], '', 2) },
+  });
+  marker(dataDir, RUN, Date.now());
+
+  assert.equal(await run([]), 0, stderr());
+  assert.match(stdout(), /ran the migration/);
+  assert.match(stdout(), /second/);
+  assert.match(stderr(), new RegExp(RUN));
+});
+
+// `--jsonl` is what makes this composable with everything else: one entry per line, parseable
+// without the header the human format carries.
+test('cli: --jsonl emits one parseable object per entry and nothing else on stdout', async (t) => {
+  const dataDir = makeDataDir();
+  const { run, stdout } = await cli(t, {
+    dataDir,
+    routes: { [LIST_ROUTE]: listPage([activityEntry(), activityEntry({ id: 'b' })], '', 2) },
+  });
+  marker(dataDir, RUN, Date.now());
+
+  assert.equal(await run(['--jsonl']), 0);
+  const lines = stdout().trim().split('\n');
+  assert.equal(lines.length, 2);
+  for (const line of lines) {
+    const parsed = JSON.parse(line);
+    assert.deepEqual(Object.keys(parsed), ['id', 'created_at', 'entry_type', 'run_id', 'content']);
+  }
+});
+
+// ===========================================================================
+// The key
+// ===========================================================================
+
+/**
+ * `--json` is the mode most likely to be piped somewhere durable — a file, a ticket, a paste.
+ * The config carries the key; nothing this command emits may.
+ */
+test('cli: --json never prints the API key, on success or on failure', async (t) => {
+  const dataDir = makeDataDir();
+  const key = 'mbt_test_0123456789abcdef_deadbeefcafebabe0123456789abcdef';
+  const { run, stdout, stderr } = await cli(t, {
+    dataDir,
+    routes: {
+      [LIST_ROUTE]: (req) => ({ status: 400, json: { error: `rejected ${req.headers.authorization}` } }),
+    },
+  });
+  marker(dataDir, RUN, Date.now());
+
+  await run(['--json']);
+  const all = stdout() + stderr();
+  assert.ok(!all.includes(key), `the key reached the output:\n${all}`);
+  assert.match(all, /REDACTED/, 'and the removal is visible rather than silent');
+});
+
+// ===========================================================================
+// --out
+// ===========================================================================
+
+test('cli: --out writes the file and reports the absolute path and byte count', async (t) => {
+  const dataDir = makeDataDir();
+  const dest = join(tempDir('mubit-out-'), 'audit.jsonl');
+  const content = '{"id":"a"}\n{"id":"b"}';
+  const { run, stdout, stderr } = await cli(t, { dataDir, routes: { [EXPORT_ROUTE]: exportBody(content) } });
+  marker(dataDir, RUN, Date.now());
+
+  assert.equal(await run(['--export', '--out', dest]), 0, stderr());
+  assert.equal(readFileSync(dest, 'utf8'), content, 'the file is the content, byte for byte');
+  // With `--out` the payload went to the file, so the summary is the output and takes stdout.
+  assert.match(stdout(), new RegExp(dest.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')),
+    'the absolute path has to be in the output — the skill has to be able to name it');
+  assert.match(stdout(), new RegExp(String(Buffer.byteLength(content))));
+});
+
+/**
+ * Refusing to overwrite is not politeness. The single most likely second run of this command
+ * is the same command again, and the file it would clobber is the artefact somebody kept.
+ */
+test('cli: --out refuses to overwrite an existing file, and dials nothing', async (t) => {
+  const dataDir = makeDataDir();
+  const dest = join(tempDir('mubit-out-'), 'audit.jsonl');
+  writeFileSync(dest, 'the artefact somebody kept');
+
+  const { server, run, stderr } = await cli(t, { dataDir, routes: { [EXPORT_ROUTE]: exportBody('{"id":"a"}') } });
+  marker(dataDir, RUN, Date.now());
+
+  assert.equal(await run(['--export', '--out', dest]), 1);
+  assert.equal(readFileSync(dest, 'utf8'), 'the artefact somebody kept');
+  assert.match(stderr(), /exists/i);
+  server.assertNotCalled('POST', '/v2/control/activity/export',);
+});
+
+/**
+ * An export inside the plugin data directory is an unbounded copy of the instance's memory
+ * sitting where nothing looks: `pruneStale`'s TTL table names the directories it sweeps, and
+ * this would not be one of them. It would live forever, grow with every run, and never appear
+ * in anything the user reads.
+ */
+test('cli: --out refuses any path inside the plugin data directory', async (t) => {
+  const dataDir = makeDataDir();
+  const { server, run, stderr } = await cli(t, { dataDir, routes: { [EXPORT_ROUTE]: exportBody('{"id":"a"}') } });
+  marker(dataDir, RUN, Date.now());
+
+  for (const dest of [
+    join(dataDir, 'audit.jsonl'),
+    join(dataDir, 'runs', 'audit.jsonl'),
+    join(dataDir, 'runs', RUN, 'deep', 'audit.jsonl'),
+    // Resolved before it is compared, so a path that only *looks* like it leaves does not.
+    join(dataDir, 'runs', '..', 'audit.jsonl'),
+  ]) {
+    assert.equal(await run(['--export', '--out', dest]), 1, `must refuse ${dest}`);
+    assert.ok(!existsSync(dest), `${dest} was written anyway`);
+  }
+  assert.match(stderr(), /data dir/i);
+  server.assertNotCalled('POST', '/v2/control/activity/export');
+});
+
+/**
+ * Not a refusal — a warning. Writing an export into a repo is a perfectly reasonable thing to
+ * do deliberately and a very bad thing to do accidentally, and the difference is whether git
+ * is about to offer it up for commit.
+ */
+test('cli: --out warns when the destination is inside a git tree and not ignored', async (t) => {
+  const dataDir = makeDataDir();
+  const repo = makeProjectDir({ git: true });
+  const dest = join(repo, 'audit.jsonl');
+  const { run, stdout, stderr } = await cli(t, { dataDir, routes: { [EXPORT_ROUTE]: exportBody('{"id":"a"}') } });
+  marker(dataDir, RUN, Date.now());
+
+  assert.equal(await run(['--export', '--out', dest]), 0, stderr());
+  assert.ok(existsSync(dest), 'a warning is not a refusal — the file is still written');
+  assert.match(stdout() + stderr(), /git|ignore/i);
+});
+
+test('cli: --out says nothing about git for a path that is ignored', async (t) => {
+  const dataDir = makeDataDir();
+  const repo = makeProjectDir({ git: true, files: { '.gitignore': 'audit.jsonl\n' } });
+  const dest = join(repo, 'audit.jsonl');
+  const { run, stdout, stderr } = await cli(t, { dataDir, routes: { [EXPORT_ROUTE]: exportBody('{"id":"a"}') } });
+  marker(dataDir, RUN, Date.now());
+
+  assert.equal(await run(['--export', '--out', dest]), 0, stderr());
+  assert.doesNotMatch(stdout() + stderr(), /not ignored/i);
+});
+
+/**
+ * A half-written export is worse than no export: it is a file that looks like a record. The
+ * file is opened only after the whole response is in hand.
+ */
+test('cli: a failed upstream writes no file at all', async (t) => {
+  const dataDir = makeDataDir();
+  const dest = join(tempDir('mubit-out-'), 'audit.jsonl');
+  const { run, stderr } = await cli(t, {
+    dataDir,
+    routes: { [EXPORT_ROUTE]: { status: 503, json: { error: 'unavailable' } } },
+  });
+  marker(dataDir, RUN, Date.now());
+
+  assert.equal(await run(['--export', '--out', dest]), 1);
+  assert.equal(existsSync(dest), false, 'a partial file is a record of nothing that reads as a record');
+  assert.match(stderr(), /503|unreachable|unavailable/i);
+});
+
+// An empty export is a failure upstream, and it stays a failure here: the command must not
+// create a zero-byte file that a reader would take for "the instance holds nothing".
+test('cli: an empty export writes no file and fails', async (t) => {
+  const dataDir = makeDataDir();
+  const dest = join(tempDir('mubit-out-'), 'audit.jsonl');
+  const { run } = await cli(t, {
+    dataDir,
+    routes: { [EXPORT_ROUTE]: { json: { format: 'jsonl', content: '', entry_count: 0 } } },
+  });
+  marker(dataDir, RUN, Date.now());
+
+  assert.equal(await run(['--export', '--out', dest]), 1);
+  assert.equal(existsSync(dest), false);
+});
+
+// ===========================================================================
+// Run resolution
+// ===========================================================================
+
+test('cli: --run wins over anything on disk', async (t) => {
+  const dataDir = makeDataDir();
+  const { server, run } = await cli(t, { dataDir, routes: { [LIST_ROUTE]: listPage([]) } });
+  marker(dataDir, 'cc-somewhere-else', Date.now());
+
+  assert.equal(await run(['--run', RUN]), 0);
+  assert.equal(server.lastCall('POST', '/v2/control/activity')?.body.run_id, RUN);
+});
+
+/**
+ * The `-c<n>` case, which is the whole reason this cannot be "the first marker in the
+ * directory". After a `/clear` the run is `cc-<slug>-<hash>-c1` while the pre-clear marker is
+ * still on disk under its twelve-hour TTL — so a resolver that ignores the counter answers
+ * with the run the user just cleared, and reports its activity as though it were this
+ * session's.
+ */
+test('cli: the newest marker wins, and a clear counter breaks a tie', async (t) => {
+  const dataDir = makeDataDir();
+  const { server, bin, run } = await cli(t, { dataDir, routes: { [LIST_ROUTE]: listPage([]) } });
+
+  const now = Date.now();
+  marker(dataDir, 'cc-proj-aaaa', now - 60_000);
+  marker(dataDir, 'cc-proj-aaaa-c1', now);
+  assert.equal(bin.pickRun(dataDir, ''), 'cc-proj-aaaa-c1');
+
+  // Same instant — which happens, because both markers can be stamped inside one tick. The
+  // counter is then the only thing that says which run this session is writing to.
+  const tie = makeDataDir();
+  marker(tie, 'cc-proj-bbbb', now);
+  marker(tie, 'cc-proj-bbbb-c2', now);
+  marker(tie, 'cc-proj-bbbb-c1', now);
+  assert.equal(bin.pickRun(tie, ''), 'cc-proj-bbbb-c2');
+
+  assert.equal(await run([]), 0);
+  assert.equal(server.lastCall('POST', '/v2/control/activity')?.body.run_id, 'cc-proj-aaaa-c1');
+});
+
+test('cli: health.json is not a run, and an empty data dir resolves to nothing', async (t) => {
+  const dataDir = makeDataDir();
+  const { bin, run, stderr } = await cli(t, { dataDir, routes: { [LIST_ROUTE]: listPage([]) } });
+
+  writeFileSync(join(dataDir, 'status', 'health.json'), JSON.stringify({ ok: true, at: Date.now() }));
+  assert.equal(bin.pickRun(dataDir, ''), '');
+  assert.equal(bin.pickRun('/nope/not/a/dir', ''), '');
+
+  // And a command with no run to work on says so rather than listing the whole instance.
+  assert.equal(await run([]), 1);
+  assert.match(stderr(), /run/i);
+});
+
+// The escape hatch, and it has to be typed. An instance-wide question is a different question.
+test('cli: --all-runs sends no run_id, and is refused for an export', async (t) => {
+  const dataDir = makeDataDir();
+  const { server, run, stderr } = await cli(t, {
+    dataDir,
+    routes: { [LIST_ROUTE]: listPage([]), [EXPORT_ROUTE]: exportBody('{"id":"a"}') },
+  });
+
+  assert.equal(await run(['--all-runs']), 0);
+  const body = server.lastCall('POST', '/v2/control/activity')?.body;
+  assert.ok(!('run_id' in body), `body was ${JSON.stringify(body)}`);
+
+  // The export route has no `limit`, so scope is its only bound and "every run" is unbounded.
+  assert.equal(await run(['--all-runs', '--export']), 2);
+  assert.match(stderr(), /--scan|scope|bound/i);
+  server.assertNotCalled('POST', '/v2/control/activity/export');
+});
+
+// ===========================================================================
+// The corrections reach the user
+// ===========================================================================
+
+/**
+ * The last mile of the design. Re-filtering client-side is worth nothing if the correction
+ * stops at the library boundary: the person reading the output is the one who has to know
+ * their instance ignored the flag they asked for.
+ */
+test('cli: an unhonoured exclude-derived is reported in the output, not swallowed', async (t) => {
+  const dataDir = makeDataDir();
+  const { run, stdout, stderr } = await cli(t, {
+    dataDir,
+    routes: {
+      [LIST_ROUTE]: listPage([
+        activityEntry({ id: 'plain' }),
+        activityEntry({ id: 'promoted', metadata_json: '{"promotion":true}' }),
+      ], '', 2),
+    },
+  });
+  marker(dataDir, RUN, Date.now());
+
+  assert.equal(await run(['--exclude-derived']), 0, stderr());
+  const all = stdout() + stderr();
+  assert.doesNotMatch(stdout(), /promoted/, 'the derived entry must not be listed');
+  assert.match(all, /did not honour|dropped|filtered locally/i,
+    'the user asked for non-derived entries and the instance sent one; that is the finding');
+});
+
+test('cli: --json carries every flag a caller would need to audit the answer', async (t) => {
+  const dataDir = makeDataDir();
+  const { run, stdout } = await cli(t, {
+    dataDir,
+    routes: { [LIST_ROUTE]: listPage([activityEntry()], '', 1) },
+  });
+  marker(dataDir, RUN, Date.now());
+
+  assert.equal(await run(['--json', '--exclude-derived']), 0);
+  const payload = JSON.parse(stdout());
+  for (const key of ['ok', 'mode', 'run', 'entries', 'totalVisible', 'droppedDerived',
+    'excludeDerivedFallbackUsed', 'projectionFallbackUsed']) {
+    assert.ok(key in payload, `--json is missing \`${key}\`: ${Object.keys(payload).join(', ')}`);
+  }
+});
+
+// A scan reports its own truncation into the output for the same reason the library reports it
+// at all: a short answer that says it is short is usable.
+test('cli: a truncated scan says so', async (t) => {
+  const dataDir = makeDataDir();
+  const { run, stdout, stderr } = await cli(t, {
+    dataDir,
+    routes: { [LIST_ROUTE]: listPage([activityEntry()], '1', 900) },
+  });
+  marker(dataDir, RUN, Date.now());
+
+  assert.equal(await run(['--scan', '--limit', '1', '--max', '2']), 0, stderr());
+  assert.match(stdout() + stderr(), /truncat|max_entries|incomplete/i);
+});

--- a/integrations/claude-code/test/activity.test.mjs
+++ b/integrations/claude-code/test/activity.test.mjs
@@ -1,0 +1,722 @@
+// @ts-check
+/**
+ * `lib/activity.mjs` — the audit question, and the two places it can be answered dishonestly.
+ *
+ * This file is written around one distinction, because everything else here follows from it.
+ *
+ * **A listing is a claim the client makes. An export is a record the server holds.** When a
+ * caller asks for non-derived entries and we print the answer under an `--exclude-derived`
+ * heading, we are asserting something about the bytes on screen — not about a field we put in
+ * a request. If the instance ignored the flag and we relayed the result anyway, we would have
+ * manufactured a false compliance artefact, which is the exact failure this module exists to
+ * remove. So the listing is re-filtered and re-projected here, and the corrections are
+ * reported: "the server did not honour this" is itself audit-relevant.
+ *
+ * The export is the mirror image. `/v2/control/activity/export` takes neither
+ * `exclude_derived` nor `projection`, so there is nothing to distrust, and `content` is
+ * written out byte for byte. A compliance artefact the client reshaped is not a record of what
+ * the server holds. The asymmetry is forced by the wire shape, and the tests below pin both
+ * halves of it.
+ *
+ * The other load-bearing property is that **asking a question about your own data must not
+ * take recall down**. `lib/http.mjs` records an abort as `not_responding` unless the caller's
+ * deadline was tighter than the 4000 ms default — and both deadlines here are looser, so
+ * without `{record: false}` five slow exports in five minutes would open the breaker and stop
+ * recall and the capture drain. That is asserted on the absence of a breaker file rather than
+ * on the presence of an option, because an option that is passed and silently dropped looks
+ * identical at the call site.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { lib, baseEnv, fakeMubit, makeDataDir } from './helpers/harness.mjs';
+
+const RUN = 'cc-here-00000001';
+const EXPORT_ROUTE = 'POST /v2/control/activity/export';
+const LIST_ROUTE = 'POST /v2/control/activity';
+
+/**
+ * A fake instance, a config pointed at it, and the module under test.
+ *
+ * @param {import('node:test').TestContext} t
+ * @param {{routes?: Record<string, any>, extra?: Record<string, string>}} [o]
+ */
+async function setup(t, o = {}) {
+  const dataDir = makeDataDir();
+  const server = await fakeMubit(o.routes ?? {});
+  t.after(() => server.close());
+  const { loadConfig } = await lib('config.mjs');
+  const cfg = loadConfig(baseEnv({ dataDir, endpoint: server.url, extra: o.extra }));
+  const mod = await lib('activity.mjs');
+  return { dataDir, server, cfg, mod };
+}
+
+/** One `ActivityEntry`, as the server actually serialises it — all sixteen fields. */
+function activityEntry(over = {}) {
+  return {
+    id: 'a3c1f0de-0000-4000-8000-000000000001',
+    run_id: RUN,
+    user_id: '',
+    actor_user_id: '',
+    agent_id: '',
+    entry_type: 'trace',
+    content: 'ran the migration',
+    source: 'claude-code',
+    importance: 'medium',
+    created_at: '2026-08-19T15:03:18Z',
+    metadata_json: '{}',
+    reference_id: 'ref_1',
+    referenceable: true,
+    upsert_key: '',
+    retrieval_mode: '',
+    origin_entry_type: 'trace',
+    ...over,
+  };
+}
+
+/** A page of the listing route. */
+function listPage(entries, next = '', total = entries.length) {
+  return { json: { entries, next_page_token: next, total_visible: total } };
+}
+
+/** The export route's reply. `format` and `entry_count` are the server's, not ours. */
+function exportBody(content, over = {}) {
+  return { json: { format: 'jsonl', content, entry_count: content ? content.split('\n').length : 0, ...over } };
+}
+
+// ===========================================================================
+// The breaker must not move
+// ===========================================================================
+
+/**
+ * The load-bearing one.
+ *
+ * `lib/http.mjs:557` tags an abort `abortedEarly` — and `settle()` at :592 then declines to
+ * record it — *only* when the caller's deadline is tighter than the 4000 ms default. Both
+ * deadlines in this module are looser, so a slow export is a full-budget abort and records
+ * `not_responding` like any hook would. Five of those inside the breaker's window opens the
+ * circuit, which stops recall and suppresses the capture drain — because the user asked a
+ * question about their own data.
+ */
+test('audit: eight failed exports leave the breaker exactly as they found it', async (t) => {
+  const { dataDir, cfg, mod } = await setup(t, {
+    routes: {
+      [EXPORT_ROUTE]: { status: 500, json: { error: 'boom' } },
+      [LIST_ROUTE]: { status: 500, json: { error: 'boom' } },
+    },
+  });
+
+  for (let i = 0; i < 8; i++) {
+    await mod.exportActivity(cfg, { run: RUN });
+    await mod.listActivity(cfg, { run: RUN });
+  }
+
+  assert.deepEqual(readdirSync(join(dataDir, 'breaker')), [],
+    'sixteen failed audit calls opened the circuit the hooks depend on; asking what memory '
+    + 'holds must never be able to stop memory working');
+});
+
+/**
+ * The deadline, stated rather than inherited.
+ *
+ * 4000 ms is a hook budget and belongs to a prompt's critical path. 20 s is the dashboard's,
+ * and it is sized for a page render. An export is a scan of every entry in a run, serialised
+ * into one string, with no `limit` on the route to bound it — so it gets its own number, and
+ * that number is longer than both.
+ */
+test('audit: EXPORT_OPTS is frozen, records nothing, and outlasts both other budgets', async (t) => {
+  const { mod } = await setup(t);
+  const dash = await lib('dashboard-api.mjs');
+
+  assert.ok(Object.isFrozen(mod.EXPORT_OPTS), 'a mutable options object is a shared global');
+  assert.equal(mod.EXPORT_OPTS.record, false);
+  assert.ok(mod.EXPORT_OPTS.timeoutMs > 4000,
+    `the hook budget is 4000 ms; an export got ${mod.EXPORT_OPTS.timeoutMs}`);
+  assert.ok(mod.EXPORT_OPTS.timeoutMs > dash.TIMEOUT_MS,
+    `an export is a bigger job than a dashboard read (${dash.TIMEOUT_MS} ms); got ${mod.EXPORT_OPTS.timeoutMs}`);
+});
+
+// ===========================================================================
+// The export route
+// ===========================================================================
+
+// `ROUTES` in `lib/http.mjs` is the frozen table of routes with a typed wrapper, a `capFor()`
+// entry and a hook caller. This one has none of those, so it lives here — the precedent
+// `lib/dashboard-api.mjs` set with `EXTRA_ROUTES` and `test/dashboard-api.test.mjs:573` pins.
+// Naming the path in a test is what stops a typo becoming a 404 that reads as "no activity".
+test('export: the route is dialled at exactly one path, and nothing else is', async (t) => {
+  const { server, cfg, mod } = await setup(t, {
+    routes: { [EXPORT_ROUTE]: exportBody('{"id":"a"}') },
+  });
+
+  const r = await mod.exportActivity(cfg, { run: RUN });
+  assert.equal(r.ok, true, `the export failed: ${JSON.stringify(r)}`);
+
+  server.assertCalled('POST', '/v2/control/activity/export', 1);
+  assert.equal(server.requests.filter((q) => q.path.startsWith('/v2/')).length, 1,
+    `an export called something else as well: ${server.summary()}`);
+  assert.equal(mod.ACTIVITY_ROUTES.export, '/v2/control/activity/export');
+  assert.ok(Object.isFrozen(mod.ACTIVITY_ROUTES));
+});
+
+/**
+ * The route takes no `limit`, and `lib/http.mjs` caps *requests*, not responses: `dial()`
+ * reads the whole body and parses it in one allocation. An empty `run_id` means "every run
+ * this key can see", so the run scope is the only bound the response has. It is therefore
+ * required, and a caller who omits it gets a refusal instead of an unbounded read.
+ */
+test('export: a missing run id dials nothing at all', async (t) => {
+  const { server, cfg, mod } = await setup(t, {
+    routes: { [EXPORT_ROUTE]: exportBody('{"id":"a"}') },
+  });
+
+  for (const params of [{}, { run: '' }, { run: '   ' }, { run: null }, { run: 42 }]) {
+    const r = await mod.exportActivity(cfg, /** @type {any} */ (params));
+    assert.equal(r.ok, false, `${JSON.stringify(params)} must refuse`);
+    assert.equal(r.code, 'bad_request');
+  }
+  server.assertNotCalled('POST', '/v2/control/activity/export');
+});
+
+/**
+ * `ExportActivityRequest` has seven fields — run_id, user_id, agent_id, entry_types,
+ * created_after, created_before, sort — and none of them is `exclude_derived`, `projection`,
+ * `limit` or `page_token`. Sending one is not an error: the handler deserialises with serde's
+ * default, which drops unknown keys silently. That is precisely why it must not be sent. A
+ * request carrying `exclude_derived` that nothing reads is a client believing it filtered.
+ */
+test('export: the body carries format and omits every field the route does not take', async (t) => {
+  const { server, cfg, mod } = await setup(t, {
+    routes: { [EXPORT_ROUTE]: exportBody('{"id":"a"}') },
+  });
+
+  await mod.exportActivity(cfg, {
+    run: RUN,
+    entryTypes: ['lesson'],
+    createdAfter: '2026-01-01T00:00:00Z',
+    createdBefore: '2026-12-31T23:59:59Z',
+    userId: 'u1',
+    agentId: 'a1',
+    // Offered by the caller and dropped on the floor, because the route cannot honour them.
+    excludeDerived: true,
+    projection: 'compact',
+    limit: 250,
+    pageToken: '100',
+  });
+
+  const body = server.lastCall('POST', '/v2/control/activity/export')?.body;
+  assert.equal(body.format, 'jsonl', 'the client states the format it will accept');
+  for (const absent of ['exclude_derived', 'projection', 'limit', 'page_token']) {
+    assert.ok(!(absent in body),
+      `the export body carries \`${absent}\`, which this route ignores. A field that is sent `
+      + 'and dropped is a filter the caller believes ran. Body: ' + JSON.stringify(body));
+  }
+  assert.equal(body.run_id, RUN);
+  assert.deepEqual(body.entry_types, ['lesson']);
+  assert.equal(body.created_after, '2026-01-01T00:00:00Z');
+  assert.equal(body.created_before, '2026-12-31T23:59:59Z');
+  assert.equal(body.user_id, 'u1');
+  assert.equal(body.agent_id, 'a1');
+});
+
+/**
+ * The whole point of the export. A compliance artefact the client reshaped is not a record of
+ * what the server holds, so `content` crosses this module untouched — no re-parse, no
+ * re-serialise, no trailing newline added, no CRLF normalisation.
+ */
+test('export: content comes back byte for byte', async (t) => {
+  // Deliberately awkward: a trailing space, a CRLF, a lone \n at the end, and a unicode
+  // codepoint outside the BMP. Any of them would survive a re-serialise; together they do not.
+  const content = '{"id":"a","c":"x "}\r\n{"id":"b","c":"\u{1F5C4}"}\n';
+  const { cfg, mod } = await setup(t, { routes: { [EXPORT_ROUTE]: exportBody(content) } });
+
+  const r = await mod.exportActivity(cfg, { run: RUN });
+  assert.equal(r.ok, true);
+  assert.equal(r.data.content, content, 'the export was reshaped in transit');
+  assert.equal(r.data.bytes, Buffer.byteLength(content, 'utf8'));
+  assert.equal(r.data.format, 'jsonl');
+});
+
+/**
+ * A zero-byte export is the one answer that must never be reported as success.
+ *
+ * "Your instance holds nothing about this run" and "the export route answered with a field we
+ * could not read" are the same empty file on disk and completely different facts. Writing the
+ * first when the second happened is the failure this whole ticket exists to prevent, so all
+ * three shapes of nothing are failures.
+ */
+test('export: an empty, absent or non-string content is a failure, never a zero-byte success', async (t) => {
+  const rows = [
+    ['', 'an empty string'],
+    [undefined, 'an absent field'],
+    [null, 'a null'],
+    [42, 'a number'],
+    [{ id: 'a' }, 'an object'],
+    [['{"id":"a"}'], 'an array of lines'],
+  ];
+
+  for (const [content, why] of rows) {
+    const { cfg, mod } = await setup(t, {
+      routes: { [EXPORT_ROUTE]: { json: { format: 'jsonl', content, entry_count: 0 } } },
+    });
+    const r = await mod.exportActivity(cfg, { run: RUN });
+    assert.equal(r.ok, false, `${why} must be a failure, not an empty export`);
+    assert.match(r.message, /content/i, `the message has to name what was wrong: ${r.message}`);
+  }
+});
+
+// The instance decides the format; we report what it said rather than what we asked for. An
+// instance that answers `csv` has not produced the JSONL a caller is about to parse, and the
+// caller needs to be able to see that rather than infer it from a parse failure.
+test('export: the format the server reports is what is surfaced, not the one requested', async (t) => {
+  const { cfg, mod } = await setup(t, {
+    routes: { [EXPORT_ROUTE]: exportBody('id,content\n1,x', { format: 'csv' }) },
+  });
+  const r = await mod.exportActivity(cfg, { run: RUN });
+  assert.equal(r.ok, true);
+  assert.equal(r.data.format, 'csv');
+  assert.equal(r.data.requestedFormat, 'jsonl');
+});
+
+// The dashboard's rule, inherited: an upstream error carries a snippet of the response that
+// produced it, and a proxy error page can quote a request header.
+test('export: an upstream error never carries the API key back to the caller', async (t) => {
+  const { cfg, mod } = await setup(t, {
+    routes: {
+      [EXPORT_ROUTE]: (req) => ({
+        status: 400,
+        json: { error: `bad request with header ${req.headers.authorization}` },
+      }),
+    },
+  });
+
+  const r = await mod.exportActivity(cfg, { run: RUN });
+  assert.equal(r.ok, false);
+  assert.ok(cfg.apiKey && cfg.apiKey.length > 10, 'the fixture must have a key, or this proves nothing');
+  assert.ok(!r.message.includes(cfg.apiKey), `the key reached the caller: ${r.message}`);
+  assert.match(r.message, /REDACTED/, 'and the removal is visible rather than silent');
+});
+
+/**
+ * No re-redaction of the content itself.
+ *
+ * The dashboard scrubs prompt text because rendering into a web page is a different consent
+ * from sending it to your own instance. Here a person is asking their own instance, in their
+ * own terminal, what it holds — and scrubbing that would defeat the compliance question
+ * exactly. Errors are still scrubbed; the record is not.
+ */
+test('export: the content is not re-redacted on the way out', async (t) => {
+  const content = '{"id":"a","content":"AKIAIOSFODNN7EXAMPLE and eldar@mubit.ai"}';
+  const { cfg, mod } = await setup(t, { routes: { [EXPORT_ROUTE]: exportBody(content) } });
+
+  const r = await mod.exportActivity(cfg, { run: RUN });
+  assert.equal(r.ok, true);
+  assert.equal(r.data.content, content,
+    'the user is asking their own instance what it holds about them; redacting the answer '
+    + 'makes the answer useless for the only question it was asked');
+});
+
+// ===========================================================================
+// Derived detection
+// ===========================================================================
+
+/**
+ * What the server means by "derived", and the four spellings past it.
+ *
+ * `list_activity`'s own `exclude_derived` drops an entry when `metadata_json` parses to an
+ * object carrying `promotion: true` or `derived: true` — as JSON booleans, via `as_bool()`.
+ * That is a narrower test than the data warrants: recurrence promotion writes
+ * `auto_promoted: true`, the A/B path writes `promoted`, a stringified boolean fails
+ * `as_bool()` outright, and `metadata_json` reaches us double-encoded often enough to matter.
+ *
+ * Erring wide is the only safe direction. Over-filtering shows a caller fewer entries than
+ * exist, which they can see; under-filtering prints a promoted fact under a heading that says
+ * there are none, which they cannot.
+ */
+test('derived: every spelling a promoted entry arrives in is detected', async (t) => {
+  const { mod } = await setup(t);
+
+  const derived = [
+    ['{"promotion":true,"promotion_confidence":0.8}', 'the promotion pipeline\'s own metadata'],
+    ['{"derived":true}', 'the second half of the server\'s own filter'],
+    ['{"promoted":true}', 'what the shadow-A/B promotion path writes'],
+    ['{"auto_promoted":true}', 'recurrence promotion — which the server\'s exclude_derived misses'],
+    ['{"derived":"true"}', 'a stringified boolean, which as_bool() rejects server-side'],
+    ['"{\\"derived\\":true}"', 'metadata_json double-encoded: a JSON string holding JSON'],
+  ];
+  for (const [metadata_json, why] of derived) {
+    assert.equal(mod.isDerived(activityEntry({ metadata_json })), true,
+      `${why}: ${metadata_json}`);
+  }
+
+  // The seventh spelling is not a string at all: the dashboard has already parsed
+  // `metadata_json` before it reaches a shared helper, and an object must not fall through.
+  assert.equal(mod.isDerived(activityEntry({ metadata_json: { promotion: true } })), true,
+    'metadata_json already parsed by the caller');
+
+  // And the flag can arrive outside the metadata entirely.
+  assert.equal(mod.isDerived(activityEntry({ derived: true })), true, 'a top-level flag');
+});
+
+test('derived: nothing that merely looks promoted is dropped', async (t) => {
+  const { mod } = await setup(t);
+
+  const kept = [
+    ['{}', 'no metadata'],
+    ['', 'an empty metadata string'],
+    ['   ', 'whitespace'],
+    ['not json at all', 'metadata that will not parse'],
+    ['[1,2,3]', 'metadata that parses to an array'],
+    ['null', 'metadata that parses to null'],
+    ['{"promotion":false}', 'the flag, explicitly false'],
+    ['{"derived":"no"}', 'a string that is not a truth value'],
+    ['{"promotion_confidence":0.9,"promotion_tier":"stable_fact"}',
+      'promotion-adjacent keys without the flag itself — an entry the promoter looked at and did not promote'],
+  ];
+  for (const [metadata_json, why] of kept) {
+    assert.equal(mod.isDerived(activityEntry({ metadata_json })), false, `${why}: ${metadata_json}`);
+  }
+
+  // Totality: this runs over every entry of an export-sized listing and cannot be the thing
+  // that throws.
+  for (const junk of [null, undefined, 42, 'x', [], () => {}]) {
+    assert.equal(mod.isDerived(/** @type {any} */ (junk)), false, `isDerived(${String(junk)})`);
+  }
+});
+
+// ===========================================================================
+// The compact projection
+// ===========================================================================
+
+/**
+ * Five keys, and the reason there are five.
+ *
+ * The server's `compact` keeps all sixteen fields and only truncates content and rewrites
+ * metadata — which is the right trade for a page render and the wrong one for reading a
+ * listing in a terminal. These five answer the audit question in full: what is it, when did it
+ * arrive, which run wrote it, what does it say, and how do I address it. Everything else is
+ * what `--full` and the export are for.
+ */
+test('compact: the projection is exactly five keys, in a fixed order', async (t) => {
+  const { mod } = await setup(t);
+
+  assert.deepEqual([...mod.COMPACT_KEYS], ['id', 'created_at', 'entry_type', 'run_id', 'content']);
+  assert.ok(Object.isFrozen(mod.COMPACT_KEYS));
+
+  const out = mod.compactEntry(activityEntry({ content: 'short' }));
+  assert.deepEqual(Object.keys(out), [...mod.COMPACT_KEYS],
+    'the key order is what a terminal reader scans down; it is part of the shape');
+  assert.equal(out.content, 'short');
+  assert.equal(out.run_id, RUN);
+
+  // Totality again, and a missing field is an empty string rather than an absent key: a
+  // JSONL stream whose rows have different keys is not a table.
+  assert.deepEqual(mod.compactEntry(/** @type {any} */ (null)),
+    { id: '', created_at: '', entry_type: '', run_id: '', content: '' });
+});
+
+// The server truncates to 200 characters and appends `...`, so a compacted row is at most 203.
+// Matching that exactly means a client truncation and a server one are the same bytes — the
+// difference is reported as a flag rather than smuggled into the content.
+test('compact: content is truncated at the same boundary the server uses', async (t) => {
+  const { mod } = await setup(t);
+  const long = 'x'.repeat(500);
+  const out = mod.compactEntry(activityEntry({ content: long }));
+  assert.equal(out.content.length, mod.COMPACT_CONTENT_CHARS + 3);
+  assert.equal(out.content, `${'x'.repeat(200)}...`);
+  assert.equal(mod.COMPACT_CONTENT_CHARS, 200);
+});
+
+// ===========================================================================
+// The two corrections
+// ===========================================================================
+
+/**
+ * "I asked for non-derived entries" is a claim about a request field. "These are the
+ * non-derived entries" is a claim about bytes. This test is the difference.
+ */
+test('listing: an ignored exclude_derived is corrected here, and reported', async (t) => {
+  const { cfg, mod } = await setup(t, {
+    routes: {
+      [LIST_ROUTE]: listPage([
+        activityEntry({ id: 'plain' }),
+        activityEntry({ id: 'promoted', metadata_json: '{"promotion":true}' }),
+        activityEntry({ id: 'recurrence', metadata_json: '{"auto_promoted":true}' }),
+      ], '', 3),
+    },
+  });
+
+  const r = await mod.listActivity(cfg, { run: RUN, excludeDerived: true });
+  assert.equal(r.ok, true);
+  assert.deepEqual(r.data.entries.map((e) => e.id), ['plain'],
+    'the instance returned promoted entries under a request that excluded them');
+  assert.equal(r.data.excludeDerivedFallbackUsed, true,
+    '"the server did not honour this" is itself audit-relevant and must reach the caller');
+  assert.equal(r.data.droppedDerived, 2);
+
+  // And `total_visible` is the server's count, over the server's filtering. It over-counts by
+  // exactly what we dropped, which a caller can only reconcile if both numbers are present.
+  assert.equal(r.data.totalVisible, 3);
+});
+
+test('listing: a server that honours exclude_derived reports no fallback', async (t) => {
+  const { server, cfg, mod } = await setup(t, {
+    routes: { [LIST_ROUTE]: listPage([activityEntry({ id: 'plain' })], '', 1) },
+  });
+
+  const r = await mod.listActivity(cfg, { run: RUN, excludeDerived: true });
+  assert.equal(r.ok, true);
+  assert.equal(r.data.excludeDerivedFallbackUsed, false);
+  assert.equal(r.data.droppedDerived, 0);
+  assert.equal(server.lastCall('POST', '/v2/control/activity')?.body.exclude_derived, true,
+    'the flag is still sent — the client filter is a check on the server, not a replacement');
+});
+
+// The mirror of the above for `projection`. Detection is structural rather than a guess: the
+// server's compact output is at most 203 characters, so anything longer is proof the flag did
+// not take effect.
+test('listing: an ignored projection is corrected here, and reported', async (t) => {
+  const { cfg, mod } = await setup(t, {
+    routes: { [LIST_ROUTE]: listPage([activityEntry({ content: 'y'.repeat(4000) })], '', 1) },
+  });
+
+  const r = await mod.listActivity(cfg, { run: RUN });
+  assert.equal(r.ok, true);
+  assert.equal(r.data.entries[0].content.length, 203);
+  assert.equal(r.data.projectionFallbackUsed, true);
+});
+
+test('listing: a server that honours projection reports no fallback', async (t) => {
+  const { cfg, mod } = await setup(t, {
+    routes: { [LIST_ROUTE]: listPage([activityEntry({ content: `${'y'.repeat(200)}...` })], '', 1) },
+  });
+  const r = await mod.listActivity(cfg, { run: RUN });
+  assert.equal(r.ok, true);
+  assert.equal(r.data.projectionFallbackUsed, false);
+});
+
+// `--full` is the escape hatch for someone who needs the other eleven fields, and it must not
+// quietly get the five-key shape.
+test('listing: the full projection passes entries through unreshaped', async (t) => {
+  const { server, cfg, mod } = await setup(t, {
+    routes: { [LIST_ROUTE]: listPage([activityEntry({ content: 'z'.repeat(1000) })], '', 1) },
+  });
+
+  const r = await mod.listActivity(cfg, { run: RUN, projection: 'full' });
+  assert.equal(r.ok, true);
+  assert.equal(r.data.entries[0].content.length, 1000, 'full means full');
+  assert.ok('reference_id' in r.data.entries[0], 'and every field survives');
+  assert.equal(r.data.projectionFallbackUsed, false, 'nothing was asked for, so nothing was ignored');
+  assert.equal(server.lastCall('POST', '/v2/control/activity')?.body.projection, 'full');
+});
+
+// `listActivity` inherits the export's scope rule, for the same reason and one more: an
+// instance-wide listing is a different question from "what does this run hold", and it should
+// be asked out loud.
+test('listing: a missing run id dials nothing unless allRuns was asked for', async (t) => {
+  const { server, cfg, mod } = await setup(t, { routes: { [LIST_ROUTE]: listPage([]) } });
+
+  const r = await mod.listActivity(cfg, {});
+  assert.equal(r.ok, false);
+  assert.equal(r.code, 'bad_request');
+  server.assertNotCalled('POST', '/v2/control/activity');
+
+  const all = await mod.listActivity(cfg, { allRuns: true });
+  assert.equal(all.ok, true);
+  const body = server.lastCall('POST', '/v2/control/activity')?.body;
+  assert.ok(!('run_id' in body), `allRuns means an absent run_id; body was ${JSON.stringify(body)}`);
+});
+
+// ===========================================================================
+// The five new request fields
+// ===========================================================================
+
+// Each of these exists on `ListActivityRequest` and none of them was reachable from this
+// plugin before. They are the difference between "show me activity" and the questions an audit
+// actually asks: since when, until when, by whom, from which agent, and without the entries
+// the instance derived for itself.
+test('listing: the new filter fields reach the wire when set', async (t) => {
+  const { server, cfg, mod } = await setup(t, { routes: { [LIST_ROUTE]: listPage([]) } });
+
+  await mod.listActivity(cfg, {
+    run: RUN,
+    entryTypes: ['lesson', 'trace'],
+    createdAfter: '2026-01-01T00:00:00Z',
+    createdBefore: '2026-06-30T00:00:00Z',
+    userId: 'u-1',
+    agentId: 'agent-1',
+    excludeDerived: true,
+  });
+
+  const body = server.lastCall('POST', '/v2/control/activity')?.body;
+  assert.deepEqual(body.entry_types, ['lesson', 'trace']);
+  assert.equal(body.created_after, '2026-01-01T00:00:00Z');
+  assert.equal(body.created_before, '2026-06-30T00:00:00Z');
+  assert.equal(body.user_id, 'u-1');
+  assert.equal(body.agent_id, 'agent-1');
+  assert.equal(body.exclude_derived, true);
+});
+
+/**
+ * The additive half, which is the whole risk of touching `fetchActivity`.
+ *
+ * Every one of the five is emitted only when it is set. An unconditional `user_id: ''` would
+ * be read server-side by `effective_logical_user_scope` and become a filter nobody asked for —
+ * the same shape as the `user_id` trap on the ingest side, where filling the field made new
+ * captures unrecallable.
+ */
+test('listing: an unset filter field is absent from the body, not empty', async (t) => {
+  const { server, cfg, mod } = await setup(t, { routes: { [LIST_ROUTE]: listPage([]) } });
+  await mod.listActivity(cfg, { run: RUN });
+
+  const body = server.lastCall('POST', '/v2/control/activity')?.body;
+  for (const key of ['user_id', 'agent_id', 'created_after', 'created_before', 'exclude_derived', 'entry_types']) {
+    assert.ok(!(key in body),
+      `\`${key}\` was sent unset. On this route an empty user_id is still read as a scope, and `
+      + `a filter nobody asked for is the hardest kind to notice. Body: ${JSON.stringify(body)}`);
+  }
+});
+
+// ===========================================================================
+// The pagination loop
+// ===========================================================================
+
+/**
+ * Written before the loop was, because this is the failure mode a paginating client has that a
+ * single-shot one does not: an instance whose `next_page_token` never advances turns a scan
+ * into an infinite request loop against the user's own server. The timeout on this test is the
+ * assertion — without the guard it does not fail, it hangs.
+ */
+test('scan: a page token that never advances stops the scan instead of hanging it',
+  { timeout: 10000 }, async (t) => {
+    const { server, cfg, mod } = await setup(t, {
+      // Always the same token, always a full page: the shape a buggy offset implementation has.
+      routes: { [LIST_ROUTE]: listPage([activityEntry()], '0', 900) },
+    });
+
+    const r = await mod.scanActivity(cfg, { run: RUN, limit: 1 });
+    assert.equal(r.ok, true);
+    assert.equal(r.data.truncated, true);
+    assert.equal(r.data.truncatedReason, 'page_token_repeated');
+    assert.ok(server.countOf('POST', '/v2/control/activity') <= 3,
+      `a non-advancing token cost ${server.countOf('POST', '/v2/control/activity')} requests`);
+  });
+
+/**
+ * Offset pagination is why the scan sorts ascending and the listing does not.
+ *
+ * The token is a numeric offset into a set the server re-derives on every request. Under
+ * `desc`, a write that lands mid-scan shifts every subsequent offset by one: the next page
+ * re-reads a row already read, and the row that moved past the boundary is never read at all.
+ * Under `asc` new rows arrive at the end, past the offsets already consumed.
+ */
+test('scan: pages ascending, and a listing pages descending', async (t) => {
+  const { server, cfg, mod } = await setup(t, {
+    routes: {
+      [LIST_ROUTE]: [
+        listPage([activityEntry({ id: 'a' })], '1', 2),
+        listPage([activityEntry({ id: 'b' })], '', 2),
+      ],
+    },
+  });
+
+  const r = await mod.scanActivity(cfg, { run: RUN, limit: 1 });
+  assert.equal(r.ok, true);
+  assert.deepEqual(r.data.entries.map((e) => e.id), ['a', 'b']);
+  assert.equal(r.data.pages, 2);
+  assert.equal(r.data.truncated, false);
+  for (const call of server.calls('POST', '/v2/control/activity')) {
+    assert.equal(call.body.sort, 'asc', 'a scan that sorts desc re-reads and misses rows');
+  }
+  assert.equal(server.calls('POST', '/v2/control/activity')[1].body.page_token, '1');
+
+  server.reset();
+  server.route(LIST_ROUTE, listPage([activityEntry()], '', 1));
+  await mod.listActivity(cfg, { run: RUN });
+  assert.equal(server.lastCall('POST', '/v2/control/activity')?.body.sort, 'desc',
+    'a single page wants the newest entries, which is what a person asking "what just happened" means');
+});
+
+// The server clamps `limit` to 1..500 and clamps a zero *up to one* rather than to a default —
+// so an omitted limit means one entry, not a hundred. Clamping here keeps the request honest
+// and keeps a caller's `--limit 0` from turning a scan into one request per entry.
+test('scan: the page size is clamped into 1..500 whatever the caller asked', async (t) => {
+  const { server, cfg, mod } = await setup(t, { routes: { [LIST_ROUTE]: listPage([]) } });
+
+  for (const asked of [undefined, 0, -5, NaN, 1.7, 10_000, '250']) {
+    server.reset();
+    await mod.scanActivity(cfg, { run: RUN, limit: /** @type {any} */ (asked) });
+    const sent = server.lastCall('POST', '/v2/control/activity')?.body.limit;
+    assert.equal(typeof sent, 'number', `limit must always be explicit; asked ${asked}`);
+    assert.ok(Number.isInteger(sent) && sent >= 1 && sent <= 500,
+      `asked ${asked}, sent ${sent}`);
+  }
+});
+
+// A scan is bounded three ways, and every one of them reports rather than trims quietly. A
+// short answer that says it is short is usable; a short answer that looks complete is the
+// false artefact again.
+test('scan: hitting the entry cap is reported, not silently trimmed', async (t) => {
+  const { cfg, mod } = await setup(t, {
+    routes: { [LIST_ROUTE]: listPage([activityEntry({ id: 'a' }), activityEntry({ id: 'b' })], '2', 900) },
+  });
+
+  const r = await mod.scanActivity(cfg, { run: RUN, limit: 2, maxEntries: 3 });
+  assert.equal(r.ok, true);
+  assert.equal(r.data.truncated, true);
+  assert.equal(r.data.truncatedReason, 'max_entries');
+  assert.ok(r.data.entries.length >= 3, 'the cap is a floor on what was collected, not a slice');
+});
+
+test('scan: running out of wall clock is reported, not silently trimmed', async (t) => {
+  const { cfg, mod } = await setup(t, {
+    routes: { [LIST_ROUTE]: { delayMs: 60, json: { entries: [activityEntry()], next_page_token: '1', total_visible: 900 } } },
+  });
+
+  const r = await mod.scanActivity(cfg, { run: RUN, limit: 1, budgetMs: 80 });
+  assert.equal(r.ok, true);
+  assert.equal(r.data.truncated, true);
+  assert.equal(r.data.truncatedReason, 'budget');
+  assert.ok(r.data.elapsedMs >= 0);
+});
+
+// A failure mid-scan is a failure. Returning the pages that did arrive, as though the scan
+// completed, is how a partial answer becomes a complete-looking one.
+test('scan: a failed page fails the scan rather than returning a partial as complete', async (t) => {
+  const { cfg, mod } = await setup(t, {
+    routes: {
+      [LIST_ROUTE]: [
+        listPage([activityEntry({ id: 'a' })], '1', 900),
+        { status: 503, json: { error: 'unavailable' } },
+      ],
+    },
+  });
+
+  const r = await mod.scanActivity(cfg, { run: RUN, limit: 1 });
+  assert.equal(r.ok, false, 'a scan that lost a page in the middle did not see everything');
+  assert.equal(r.code, 'upstream_unreachable');
+});
+
+// The corrections survive the loop: a scan is the listing repeated, and a promoted entry on
+// page four is exactly as wrong as one on page one.
+test('scan: the client-side corrections apply across every page', async (t) => {
+  const { cfg, mod } = await setup(t, {
+    routes: {
+      [LIST_ROUTE]: [
+        listPage([activityEntry({ id: 'a' })], '1', 3),
+        listPage([activityEntry({ id: 'promoted', metadata_json: '{"promotion":true}' })], '2', 3),
+        listPage([activityEntry({ id: 'c', content: 'q'.repeat(900) })], '', 3),
+      ],
+    },
+  });
+
+  const r = await mod.scanActivity(cfg, { run: RUN, limit: 1, excludeDerived: true });
+  assert.equal(r.ok, true);
+  assert.deepEqual(r.data.entries.map((e) => e.id), ['a', 'c']);
+  assert.equal(r.data.excludeDerivedFallbackUsed, true);
+  assert.equal(r.data.projectionFallbackUsed, true);
+  assert.equal(r.data.droppedDerived, 1);
+});

--- a/integrations/claude-code/test/skills.test.mjs
+++ b/integrations/claude-code/test/skills.test.mjs
@@ -39,8 +39,22 @@ const SERVER_BUNDLE = join(PLUGIN_ROOT, 'mcp', 'dist', 'server.js');
 /** §3.2 matcher note — `.mcp.json` names the server `mubit`. */
 const QUALIFIED_PREFIX = 'mcp__plugin_mubit-memory_mubit__';
 
-/** §2/§9 — the skills the plugin ships. `auth` is the seventh and `dashboard` the eighth. */
-const SKILLS = ['recall', 'remember', 'reflect', 'forget', 'doctor', 'setup', 'auth', 'dashboard'];
+/**
+ * §2/§9 — the skills the plugin ships, in the order they arrived. One per line, because four
+ * branches add to this list at once and a merge should be able to take both sides of a
+ * conflict without re-reading a wrapped array.
+ */
+const SKILLS = [
+  'recall',
+  'remember',
+  'reflect',
+  'forget',
+  'doctor',
+  'setup',
+  'auth',
+  'dashboard',
+  'activity',
+];
 
 /**
  * The two skills that call no MCP tool, and cannot.
@@ -571,4 +585,108 @@ test('remember/SKILL.md names the setting that widens what an agent may write', 
   const { body } = loadSkill('remember');
   assert.match(body, /mcpLessonScope|MUBIT_MCP_LESSON_SCOPE/,
     'remember/SKILL.md does not name the setting that raises the scope ceiling (§6.2)');
+});
+
+// ---------------------------------------------------------------------------
+// §9 — activity
+// ---------------------------------------------------------------------------
+
+/**
+ * Like `auth` and `dashboard`, this skill runs a bundled script rather than calling an MCP
+ * tool, so its grant is `allowed-tools` (a Bash permission rule) and not `tools` (the MCP
+ * grant). A `tools:` entry naming a Bash command matches nothing and fails silently, and the
+ * host then prompts for approval on every run.
+ */
+test('activity/SKILL.md grants exactly the Bash permission it needs, and no MCP tools', () => {
+  const { fm } = loadSkill('activity');
+
+  const allowed = fm['allowed-tools'];
+  assert.ok(allowed, 'activity must declare allowed-tools so the host does not prompt on every run');
+  const text = Array.isArray(allowed) ? allowed.join(' ') : String(allowed);
+
+  assert.match(text, /Bash\(/, 'the grant is a Bash permission rule');
+  assert.match(text, /bin\/activity\.mjs/, 'the rule must name the script, not hand the skill a shell');
+  assert.match(text, /\$\{CLAUDE_PLUGIN_ROOT\}/,
+    'the plugin is installed at a path nobody can predict — a relative path resolves elsewhere');
+
+  assert.equal(toolsOf(fm), undefined,
+    'the command talks to the control API itself; an MCP grant would be a second, weaker path to it');
+});
+
+/**
+ * The second skill in the set the model may not invoke, for the same two reasons as the first.
+ *
+ * Pulling a copy of everything an instance holds into a transcript is a thing a person decides
+ * to do. It is also what makes this skill free: a `disable-model-invocation: true` skill's
+ * description is not loaded into context, so it costs nothing until somebody types it — and
+ * `/mubit-memory:doctor` already owns the cheaper, model-facing "is capture working" question.
+ */
+test('activity/SKILL.md is user-invocable but never model-invocable', () => {
+  const { fm } = loadSkill('activity');
+  assert.equal(fm['disable-model-invocation'], true,
+    'nothing in a conversation should decide on its own to export somebody\'s memory');
+});
+
+/**
+ * The guard that matters most, because without it the model will describe an export as
+ * "filtered activity" — the exact false claim the module's design exists to prevent.
+ *
+ * `/v2/control/activity/export` accepts neither `exclude_derived` nor `projection`. An export
+ * is therefore always everything in scope, and a user who asked for "an export of my
+ * non-derived entries" is asking for two different operations. A skill that blurs the two
+ * produces a reply asserting a filter that never ran.
+ */
+test('activity/SKILL.md keeps the listing and the export distinguishable', () => {
+  const { body } = loadSkill('activity');
+  assert.match(body, /never filtered|not filtered|accepts no `?exclude_derived/i,
+    'the skill must say outright that an export carries no filter');
+  assert.match(body, /verbatim|byte for byte/i,
+    'and that its content is what the instance holds rather than something this client shaped');
+  assert.match(body, /never describe an export as/i,
+    'the instruction has to be an instruction, not an implication — this is the sentence that '
+    + 'stops "here is your filtered export"');
+});
+
+/**
+ * Writing a file is the only irreversible thing this command does, and the model is what
+ * decides whether it happens.
+ */
+test('activity/SKILL.md forbids --out unless the user asked for a file, and requires naming the path', () => {
+  const { body } = loadSkill('activity');
+  assert.match(body, /Do not pass `--out` unless/i,
+    'an export is a complete copy of somebody\'s memory; creating one is their decision');
+  assert.match(body, /absolute path/i,
+    'a file the user cannot find is a file they cannot delete — the reply has to name it');
+  assert.match(body, /refuses to overwrite/i, 'the second run of this command is the first one again');
+  assert.match(body, /data dir/i,
+    'an export inside the data dir sits outside the TTL sweep and is never mentioned again');
+});
+
+/**
+ * The corrections are worth nothing if they stop at the terminal. When the instance ignores a
+ * filter, that fact is the finding — and the model is the thing that decides whether the user
+ * ever hears it.
+ */
+test('activity/SKILL.md tells the model to relay the findings rather than summarise them away', () => {
+  const { body } = loadSkill('activity');
+  assert.match(body, /did not honour/i,
+    'the skill must name the "the instance ignored this" line as something to pass on');
+  assert.match(body, /incomplete|prefix/i,
+    'a truncated scan reported as a complete answer is the same lie as an unhonoured filter');
+  assert.match(body, /Relay|rather than summaris/i,
+    'the model\'s default is to compress a note out of existence; this is what stops it');
+});
+
+// `scripts/mubit-inspect.mjs` is not in `files` and is not shipped: it carries untested copies
+// of data-dir discovery and the marker/turn join that `lib/dashboard-data.mjs` now owns with
+// tests behind it, and its HTTP paths have neither breaker discipline nor a deadline. The
+// question it answers — per-prompt cost — is real, so the skill has to route the reader at the
+// surface that does ship it rather than leaving a gap somebody fills with the unshipped script.
+test('activity/SKILL.md routes the per-prompt question at the dashboard, not at a script that does not ship', () => {
+  const { body } = loadSkill('activity');
+  assert.match(body, /Turns/,
+    'per-prompt cost lives in the dashboard\'s Turns tab; this skill cannot answer it');
+  assert.ok(!body.includes('mubit-inspect'),
+    'mubit-inspect.mjs is not in package.json `files` — naming it sends a user to a path that '
+    + 'does not exist in an installed plugin');
 });

--- a/integrations/codex/README.md
+++ b/integrations/codex/README.md
@@ -149,7 +149,7 @@ asking how well attested a lesson is.
 
 ## Skills
 
-Seven, listed to the model as `mubit-memory:<name>`:
+Listed to the model as `mubit-memory:<name>`:
 
 | Skill | For |
 | --- | --- |
@@ -160,6 +160,7 @@ Seven, listed to the model as `mubit-memory:<name>`:
 | `reflect` | Extract lessons from this run now, rather than at session end. |
 | `forget` | Delete an entry, or down-weight one that is merely wrong. |
 | `doctor` | Diagnose. Its step 0 is the Codex-specific one: hooks that were never trusted. |
+| `activity` | The audit question: what this instance actually holds, filtered by time, type, agent or origin — and an export of the whole record as JSONL. Prints to stdout; writes a file only if asked. |
 
 There is no `mubit-recall` subagent here. Codex has no plugin-defined agent types — every
 `SubagentStart` reports `agent_type: "default"` — so a markdown subagent would be a file

--- a/integrations/codex/esbuild.config.mjs
+++ b/integrations/codex/esbuild.config.mjs
@@ -176,6 +176,10 @@ const targets = [
   // this to obtain the credential every other tool needs — so a Codex plugin without it has
   // no first-run story at all.
   { entryPoints: [resolve(SHARED, 'bin', 'auth.src.mjs')], outfile: out('bin/auth.mjs'), ...shared },
+  // The activity binary. The `activity` skill ships under both hosts and its only instruction
+  // is to run this file, so without the target the Codex copy of the skill names a path that
+  // does not exist — the same first-run dead end `auth` would have.
+  { entryPoints: [resolve(SHARED, 'bin', 'activity.src.mjs')], outfile: out('bin/activity.mjs'), ...shared },
   // The dashboard binary, built from the same shared source as the Claude Code copy. Two
   // installable plugins cannot share a path — the same reason this tree carries its own
   // `mcp/dist/server.js` — so the bundle is emitted here rather than referenced across.

--- a/integrations/codex/skills/activity/SKILL.md
+++ b/integrations/codex/skills/activity/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: activity
+description: "Answer the audit question: list what this Mubit instance actually holds for a run, filter it by time, type, agent or origin, and export the whole record as JSONL. Use when the user asks what memory has stored about them, or for a copy of it they can keep — and only then. Read-only."
+---
+
+**This skill never installs anything, and it writes nothing anywhere unless asked.** It runs one
+Node process from the plugin directory, makes one or more read-only calls to the configured
+instance, and prints the answer.
+
+**Do not run it on your own initiative.** This is a question a person asks about their own data;
+nothing in a conversation should decide by itself to pull a copy of somebody's memory into the
+transcript. The Claude Code copy of this skill enforces that with
+`disable-model-invocation: true`, a key Codex does not read — so under this host the rule is
+this paragraph, and it is on you to keep it.
+
+## Step 0 — resolve the binary
+
+No environment variable carries this plugin's path under Codex. Codex lists each skill with the
+absolute path of its `SKILL.md`; **this file** is at `<plugin-root>/skills/activity/SKILL.md`,
+so the binary is two directories above it:
+
+```
+<plugin-root>/bin/activity.mjs
+```
+
+Resolve that to an absolute path from this file's own location and use it in every command
+below. Do not write `${CLAUDE_PLUGIN_ROOT}`: Codex sets no plugin-root variable of any spelling,
+so the shell expands it to nothing and `node /bin/activity.mjs` fails with ENOENT.
+
+## The distinction that decides which command to run
+
+There are two things this command can produce and they are **not the same kind of answer**.
+
+- **A listing** is a claim *this client* makes. The plugin sends the filters, and then checks
+  the result against them itself: it re-drops derived entries and re-truncates content, and it
+  says so when it had to. A listing is for reading.
+- **An export** is the record *the instance holds*, byte for byte. `/v2/control/activity/export`
+  accepts no `exclude_derived` and no `projection` at all, so an export is never filtered and
+  never truncated, and nothing here reshapes it. An export is for keeping.
+
+**Never describe an export as "filtered activity".** If somebody asks for "an export of my
+non-derived lessons", they are asking for two different operations: an export is everything in
+scope, and the filtering they want is a listing. Say which one they got.
+
+## Reading it
+
+```bash
+node <plugin-root>/bin/activity.mjs
+node <plugin-root>/bin/activity.mjs --exclude-derived --type lesson
+node <plugin-root>/bin/activity.mjs --scan --since 2026-08-01T00:00:00Z
+```
+
+The default is one page of the newest activity for the newest run in this data directory.
+`--scan` pages through everything that matches, oldest first. `--run <id>` picks a run and
+`--all-runs` asks across every run the key can see.
+
+Filters: `--type` (repeatable), `--since` / `--until` as RFC3339, `--agent`, `--user`, and
+`--exclude-derived` for the entries the instance promoted for itself rather than ones a client
+wrote. `--full` returns every field untruncated; the default is five keys per entry.
+
+Output: a table by default, `--jsonl` for one object per line, `--json` for one envelope. The
+payload goes to stdout and the summary to stderr, so a pipe gets only the data.
+
+## Exporting it
+
+```bash
+node <plugin-root>/bin/activity.mjs --export
+node <plugin-root>/bin/activity.mjs --export --out ~/mubit-audit.jsonl
+```
+
+Without `--out` the JSONL goes to stdout, which is the whole point: it composes, and it leaves
+nothing on anybody's disk.
+
+**Do not pass `--out` unless the user asked for a file.** An export is a complete copy of what
+the instance holds for a run, and creating one is a decision that belongs to them, not to a turn
+that seemed like it might want one. When you do pass it, **name the absolute path in your
+reply** — the command prints it, and a file the user cannot find is a file they cannot delete.
+
+`--out` refuses to overwrite, and refuses any path inside the plugin data directory: an export
+there sits outside the TTL sweep, so it would live forever and nothing would ever mention it
+again. It warns when the destination is inside a git working tree that is not ignoring it.
+`--all-runs` is refused with `--export`, because that route takes no limit and a run is the only
+bound on how much comes back.
+
+## The data directory, which matters more here
+
+Codex and Claude Code write to **different** directories, and the run this command defaults to
+is the newest run marker in the one this host is configured for. If the listing is empty or
+names a run you do not recognise, that is the first thing to check — pass `--run <id>` to be
+sure, or `--all-runs` to stop depending on the local state entirely.
+
+## What to say about the numbers
+
+Three of the things this prints are **findings**, not decoration, and they are the reason the
+answer can be trusted. Relay them rather than summarising them away:
+
+1. **"the instance did not honour exclude_derived"** means derived entries came back under a
+   request that excluded them, and this client dropped them locally. The listing is correct; the
+   server's filter is not. That is worth telling the user, because it is the difference between
+   a filter and a claim about a filter.
+2. **"the instance did not honour the compact projection"** means content was truncated here
+   rather than upstream. Nothing was lost — `--full` or an export has all of it.
+3. **"this answer is incomplete"** on a `--scan` means it stopped at a bound (entry cap, wall
+   clock, or page count). It is a prefix, not the whole record. Say so; do not present it as a
+   complete answer, and do not quietly re-run with a bigger cap without saying why.
+
+`visible upstream` is the instance's own count of everything matching the filters it applied,
+before paging — so when the first finding fires, it is larger than the number of rows shown by
+exactly the number that were dropped here.
+
+## The one thing it cannot tell you
+
+Per-prompt recall cost and latency are not in the activity feed; they are local, under
+`runs/<run_id>/turns/`. The `dashboard` skill's **Turns** tab is where that lives, joined
+against the instance's side of the same session. Use this skill for what the instance holds and
+that tab for what each prompt cost.
+
+## Related
+
+- `dashboard` — the same data as a page, plus the local per-prompt series.
+- `doctor` — the cheaper question, and the right one when something is broken rather than merely
+  unknown.
+- `forget` — what to run when this listing turns up something that should not be there.

--- a/integrations/codex/test/codex-manifests.test.mjs
+++ b/integrations/codex/test/codex-manifests.test.mjs
@@ -46,8 +46,22 @@ const P = {
   ccPlugin: join(SHARED_ROOT, '.claude-plugin', 'plugin.json'),
 };
 
-/** §2 — the seven skills, the same seven the Claude Code plugin ships. */
-const SKILLS = ['recall', 'remember', 'reflect', 'forget', 'doctor', 'setup', 'auth', 'dashboard'];
+/**
+ * §2 — the skills, the same set the Claude Code plugin ships, in the order they arrived. One
+ * per line, because several branches add to this list at once and a merge should be able to
+ * take both sides of a conflict without re-reading a wrapped array.
+ */
+const SKILLS = [
+  'recall',
+  'remember',
+  'reflect',
+  'forget',
+  'doctor',
+  'setup',
+  'auth',
+  'dashboard',
+  'activity',
+];
 
 /** `.mcp.json` names the server `mubit`, so the model sees `mcp__mubit__<tool>`. */
 const MCP_SERVER = 'mubit';

--- a/integrations/codex/test/codex-skills.test.mjs
+++ b/integrations/codex/test/codex-skills.test.mjs
@@ -27,7 +27,22 @@ import { join } from 'node:path';
 import { CODEX_ROOT, SHARED_ROOT } from './helpers/codex-fixtures.mjs';
 
 const SKILLS_DIR = join(CODEX_ROOT, 'skills');
-const SKILLS = ['recall', 'remember', 'reflect', 'forget', 'doctor', 'setup', 'auth', 'dashboard'];
+/**
+ * The skills this plugin ships, in the order they arrived. One per line, because several
+ * branches add to this list at once and a merge should be able to take both sides of a
+ * conflict without re-reading a wrapped array.
+ */
+const SKILLS = [
+  'recall',
+  'remember',
+  'reflect',
+  'forget',
+  'doctor',
+  'setup',
+  'auth',
+  'dashboard',
+  'activity',
+];
 
 /**
  * The two skills that call no MCP tool: `auth` runs `bin/auth.mjs` to get a key, and
@@ -303,4 +318,83 @@ test('the two plugins ship the same eight skill names', () => {
   //   other is a gap somebody meant to fill and forgot.
   assert.deepEqual(codexDirs, ccDirs,
     'the skill sets have diverged. The files differ by host; the set should not.');
+});
+
+// ===========================================================================
+// activity
+// ===========================================================================
+
+test('activity: no runnable command interpolates ${CLAUDE_PLUGIN_ROOT}', () => {
+  const { body, fenced } = read('activity');
+  // § docs/harness-probe.md §4: Codex exports no plugin-root variable of any spelling. The
+  //   Claude Code copy's `node ${CLAUDE_PLUGIN_ROOT}/bin/activity.mjs` expands to
+  //   `node /bin/activity.mjs` in the login shell Codex runs commands in — ENOENT, on the one
+  //   command whose entire job is to prove the plugin can show its work.
+  assert.ok(!fenced.includes('${CLAUDE_PLUGIN_ROOT}'),
+    'a runnable command in the activity skill interpolates ${CLAUDE_PLUGIN_ROOT}, which is '
+    + 'empty under Codex.');
+  assert.match(body, /Do not write .*CLAUDE_PLUGIN_ROOT|no plugin-root variable/,
+    'the skill should say so outright as well — this is the mistake anyone porting from the '
+    + 'Claude Code skill makes.');
+  assert.match(fenced, /bin\/activity\.mjs/, 'the activity skill must still name the binary it runs.');
+  assert.match(body, /SKILL\.md|this file|skill directory/i,
+    'Codex lists each skill with its absolute SKILL.md path, which is the anchor that works.');
+});
+
+/**
+ * The `disable-model-invocation: true` that the Claude Code copy carries has no equivalent
+ * here — the key does not exist in the Codex binary — so the rule has to survive as prose or
+ * not at all. Without it a model that reads "list what memory holds" will do exactly that,
+ * unprompted, and pull somebody's whole memory into a transcript.
+ */
+test('activity: keeps the do-not-invoke-yourself rule that Codex cannot enforce', () => {
+  const { body } = read('activity');
+  assert.match(body, /own initiative|only then|never on your own/i,
+    'Codex reads no disable-model-invocation key, so this paragraph is the whole control.');
+});
+
+/**
+ * The guard that matters most, and the reason it is duplicated across both hosts: without it
+ * the model will describe an export as "filtered activity", which is the precise false claim
+ * the design prevents. `/v2/control/activity/export` accepts neither `exclude_derived` nor
+ * `projection`, so an export is always everything in scope.
+ */
+test('activity: keeps the listing and the export distinguishable', () => {
+  const { body } = read('activity');
+  assert.match(body, /never filtered|not filtered|accepts no `?exclude_derived/i,
+    'the skill must say outright that an export carries no filter');
+  assert.match(body, /verbatim|byte for byte/i,
+    'and that its content is what the instance holds rather than something this client shaped');
+  assert.match(body, /never describe an export as/i,
+    'the instruction has to be an instruction — this is the sentence that stops "here is your '
+    + 'filtered export"');
+});
+
+test('activity: forbids --out unless the user asked for a file', () => {
+  const { body } = read('activity');
+  // § Writing a file is the only irreversible thing the command does, and the model decides
+  //   whether it happens. An export is a complete copy of what the instance holds.
+  assert.match(body, /Do not pass `--out` unless/i, 'creating the copy is the user\'s decision');
+  assert.match(body, /absolute path/i,
+    'a file the user cannot find is a file they cannot delete — the reply has to name it');
+});
+
+test('activity: tells the model to relay the findings rather than summarise them away', () => {
+  const { body } = read('activity');
+  // § A correction that stops at the terminal is no correction. "The instance ignored the
+  //   filter you asked for" is the finding, and compressing it out is the model's default.
+  assert.match(body, /did not honour/i);
+  assert.match(body, /incomplete|prefix/i,
+    'a truncated scan reported as a complete answer is the same lie as an unhonoured filter');
+  assert.match(body, /Relay|rather than summaris/i);
+});
+
+test('activity: does not name a script this plugin does not ship', () => {
+  const { body } = read('activity');
+  // § `scripts/mubit-inspect.mjs` is Claude-Code-side, untested, and not in either plugin's
+  //   `files`. The question it answers is real, so the skill routes at the surface that ships.
+  assert.ok(!body.includes('mubit-inspect'),
+    'naming it sends a user to a path that does not exist in an installed plugin');
+  assert.match(body, /Turns/,
+    'per-prompt cost lives in the dashboard\'s Turns tab; this skill cannot answer it');
 });


### PR DESCRIPTION
W2-3. `/mubit-memory:activity` — what this instance actually holds, and a copy of it you can keep.

## The premise, corrected

`pre-main` already shipped `fetchActivity()` over `/v2/control/activity`. What did not exist anywhere: the export route, the request fields `exclude_derived` / `projection` / `created_after` / `created_before` / `user_id` / `agent_id`, pagination, client-side re-filtering, and any surface outside the dashboard's browser UI — whose three tabs are Memory, Turns and Analytics, and whose only call to activity is a `created_at` join inside `createdAtIndex`.

## The decision that carries the rest

**A listing is a claim the client makes. An export is a record the server holds.** The asymmetry is forced by the wire rather than chosen.

`exclude_derived` and `projection` are the two fields whose purpose *is* the compliance answer. "I asked for non-derived entries" is a claim about a request field; "these are the non-derived entries" is a claim about bytes. If the instance ignores the flag and we print the result under an `--exclude-derived` heading, we have manufactured a false audit artefact — the precise failure this ticket exists to remove. So the listing is re-filtered and re-projected client-side, and both corrections are reported: `excludeDerivedFallbackUsed` / `projectionFallbackUsed` exist because *"the server did not honour this"* is itself the finding, and the SKILL.md tells the model to relay it rather than summarise it away.

`/v2/control/activity/export` takes neither field — `ExportActivityRequest` has exactly seven, and the handler deserialises with serde's default, so sending one is not an error, it is a client believing it filtered. Nothing to distrust, so `content` is written **verbatim**: no re-parse, no re-serialise, no added newline, no re-redaction. Both halves are pinned by tests.

## Breaker safety

`lib/http.mjs:557` tags an abort `abortedEarly` — and `settle()` at :592 declines to record it — *only* when the caller's deadline is tighter than the 4000 ms default. 20 s and 45 s are both looser, so without `{record: false}` a slow export records `not_responding`, and five inside the window opens the circuit and stops recall and the capture drain because the user asked a question about their own data. The test asserts **the absence of a breaker file**, not the presence of an option: an option that is passed and silently dropped looks identical at the call site.

## stdout by default

`--out` is opt-in, which resolves the consent question by not having one. The payload owns stdout and the summary goes to stderr — unless `--out` took the payload, in which case the summary is the output. `--out` refuses to overwrite, refuses any path inside the data dir (an export there sits outside `pruneStale`'s TTL table: it would live forever and nothing would ever mention it again), prints the absolute path and byte count, and warns when the destination is inside a git tree that is not ignoring it. Nothing is opened until the whole response is in hand, so a failure writes no file rather than a file that looks like a record.

## Two answers from the backend

- **`/activity/export` accepts no `limit`** — and no `page_token`, `exclude_derived` or `projection` either. Run scope is the only bound on a body `dial()` reads and parses in one allocation, which is why a run id is required and why `--all-runs --export` is refused with a pointer at `--scan`.
- **`total_visible` counts the entries left after the server's filters and before paging**, out of a pool it caps while collecting. It over-counts by exactly what the client re-filter dropped, which is why `droppedDerived` prints beside it.

## Smaller decisions

- A **module-local route constant**, not `lib/http.mjs`'s `ROUTES` — that is the frozen table of routes with a typed wrapper, a `capFor()` entry and a hook caller. `EXTRA_ROUTES` set the precedent.
- **Listings sort `desc`, scans sort `asc`**: pagination is offset-style, and under `desc` a write landing mid-scan shifts every later offset — the next page re-reads a row and the row past the boundary is never read.
- **Derived detection is wider than the server's own.** `list_activity` checks `promotion` and `derived` via `as_bool()`, missing `auto_promoted` (recurrence promotion), `promoted`, stringified booleans, and a double-encoded `metadata_json`. Over-filtering shows fewer entries than exist, which a reader can see; under-filtering prints a derived entry under a heading saying there are none, which they cannot.
- **`pickRun()` stays local** to `bin/activity.src.mjs` at twenty lines. Three branches want the same thing this wave; a conflict inside `resolveRunId` is worse than a duplicate. Duplicate small, extract after.
- `fetchActivity` gains five parameters, **each emitted only when set**. An unconditional `user_id: ''` is read server-side by `effective_logical_user_scope` and becomes a retrieval filter nobody asked for. `test/dashboard-api.test.mjs` is untouched and stays 30/30.

## Tests

claude-code 1289 → **1296**, 0 fail, same under `test:dist`. codex 323 → **334**, 1 fail. 29 in `test/activity.test.mjs`, 20 in `test/activity-cli.test.mjs`, 6 skill guards each side.

Written first: breaker safety and the export contract, failing with `lib/activity.mjs does not exist yet`. The non-advancing-page-token test was written before the pagination loop and carries a timeout, because without the guard it does not fail — it hangs.

## Red on purpose

- `integrations/codex/test/codex-dist.test.mjs` — `bin/activity.mjs` is generated and uncommitted; a parallel ticket owns the rebuild.
- `node scripts/verify-manifests.mjs` — the contextCost skill surface, which W2-5 re-measures.

`mcp/dist/server.js` untouched at `8295edfe6ca4207f603712db95552e39`. `test/dist-freshness.test.mjs` on the Claude Code side stays **green**, because it checks `hooks/dist` and `mcp/dist` and not `bin/`.

## Deviations from the brief

- The esbuild target was added to **both** configs. The Codex copy of the skill's only instruction is `node <plugin-root>/bin/activity.mjs`; without the target that skill names a path that does not exist.
- `integrations/codex/test/codex-manifests.test.mjs` carries a **third** `SKILLS` array the shared-file protocol did not name. Rewritten one-name-per-line like the other two, so the merge resolves the same way.
- The Codex README's skills table was already missing `dashboard` before this branch. Left alone; the stale "Seven," count was dropped rather than corrected to a number nobody maintains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0144iBiKzMKGEbg4WWk8r9zQ