### PR TITLE
fix(security): judge an embedded source by its text, not its name

### DIFF
--- a/.github/leakcheck/rules.mjs
+++ b/.github/leakcheck/rules.mjs
@@ -46,7 +46,7 @@ export const CONFIG = {
    * exactly the file that needed it most.
    */
   textExtensions: [
-    '.mjs', '.js', '.cjs', '.ts', '.mts', '.json', '.md', '.yml', '.yaml', '.sh',
+    '.mjs', '.js', '.cjs', '.ts', '.tsx', '.mts', '.json', '.md', '.yml', '.yaml', '.sh',
     '.txt', '.toml', '.html', '.css', '.gitignore', '.env', '.lock',
   ],
 

--- a/.github/scripts/leakcheck.mjs
+++ b/.github/scripts/leakcheck.mjs
@@ -286,40 +286,82 @@ function commentBlocks(lines) {
  *
  * The test is not "does this file have a sourcemap". Most of the committed bundles do, and
  * theirs only carry sources that are themselves tracked here, which leaks nothing. The test is
- * whether the map carries content for a source this repository does not have.
+ * whether the map carries *text* this repository does not publish — matching the tracked
+ * file's name is not enough, because a bundle that was not rebuilt keeps embedding what the
+ * file used to say. Thirty-six stale copies passed on their basenames alone before this
+ * compared content.
  *
- * @returns {string[]} source paths whose original text is embedded but not tracked here
+ * @returns {Array<{source:string, content:string}>} every embedded source with its text
  */
-function embeddedForeignSources(path, src, tracked) {
+function inlineMapEntries(path, src) {
   if (!/\.(?:js|mjs|cjs)$/.test(path)) return [];
   const text = src.read(path);
   if (text === null) return [];
-  const at = text.lastIndexOf('sourceMappingURL=data:');
-  if (at === -1) return [];
-  const encoded = /base64,([A-Za-z0-9+/=]+)/.exec(text.slice(at));
-  if (!encoded) return [];
-
-  let map;
-  try { map = JSON.parse(Buffer.from(encoded[1], 'base64').toString('utf8')); } catch { return []; }
-  const sources = Array.isArray(map.sources) ? map.sources : [];
-  const contents = Array.isArray(map.sourcesContent) ? map.sourcesContent : [];
-  if (contents.length === 0) return [];
-
-  const basenames = new Set(tracked.map((p) => p.split('/').pop()));
-  const foreign = [];
-  for (let i = 0; i < sources.length; i += 1) {
-    if (!contents[i]) continue;
-    const src = String(sources[i]);
-    if (src.includes('node_modules/')) continue;          // third-party, published already
-    if (basenames.has(src.split('/').pop() || '')) continue; // we ship this source ourselves
-    foreign.push(src);
+  const out = [];
+  for (const m of text.matchAll(/sourceMappingURL=data:[^,\n]*;base64,([A-Za-z0-9+/=]+)/g)) {
+    let map;
+    try { map = JSON.parse(Buffer.from(m[1], 'base64').toString('utf8')); } catch { continue; }
+    const sources = Array.isArray(map.sources) ? map.sources : [];
+    const contents = Array.isArray(map.sourcesContent) ? map.sourcesContent : [];
+    for (let i = 0; i < sources.length; i += 1) {
+      if (!contents[i]) continue;
+      out.push({ source: String(sources[i]), content: String(contents[i]) });
+    }
   }
-  return foreign;
+  return out;
+}
+
+/**
+ * An embedded source is published already when a tracked file carries the same text — the
+ * map is then republishing what the tree says anyway. Compared after trimming trailing
+ * whitespace, because bundlers disagree with editors about final newlines and a stale copy
+ * differs by sentences, not by a byte at the end.
+ */
+function publishedCopy(entry, tracked, src) {
+  if (entry.source.includes('node_modules/')) return true; // third-party, published already
+  const base = entry.source.split('/').pop() || '';
+  const want = entry.content.replace(/\s+$/, '');
+  for (const p of tracked) {
+    if ((p.split('/').pop() || '') !== base) continue;
+    const text = src.read(p);
+    if (text !== null && text.replace(/\s+$/, '') === want) return true;
+  }
+  return false;
 }
 
 /* -------------------------------------------------------------------------- */
 /* scan                                                                        */
 /* -------------------------------------------------------------------------- */
+
+/**
+ * The two-pass content match over one body of text: line by line for what a reader expects,
+ * then over joined comment runs, because prose wraps and a rule anchored to a line is
+ * defeated by a line break. `seen` dedupes by fingerprint across every body scanned under
+ * the same reported path — a bundle and the sources its map embeds are one publication.
+ */
+function matchContent(compiled, lines, path, findings, seen) {
+  const consider = (rule, re, haystack, lineNo) => {
+    re.lastIndex = 0;
+    let m;
+    while ((m = re.exec(haystack)) !== null) {
+      if (m[0] === '') { re.lastIndex += 1; continue; }
+      if (!keepMatch(rule, m[0])) continue;
+      if (suppressed(lines, lineNo - 1, rule.id)) continue;
+      const f = record(rule, path, lineNo, m[0]);
+      if (seen.has(f.fingerprint)) continue;
+      seen.add(f.fingerprint);
+      findings.push(f);
+    }
+  };
+
+  for (let i = 0; i < lines.length; i += 1) {
+    if (!lines[i]) continue;
+    for (const { rule, re } of compiled) consider(rule, re, lines[i], i + 1);
+  }
+  for (const block of commentBlocks(lines)) {
+    for (const { rule, re } of compiled) consider(rule, re, block.text, block.line);
+  }
+}
 
 function scan(paths, allTracked, src) {
   /** @type {Array<{rule:string,severity:string,path:string,line:number,match:string,why:string,fix:string,fingerprint:string}>} */
@@ -348,11 +390,25 @@ function scan(paths, allTracked, src) {
       if (rule) findings.push(record(rule, path, 1, `${(size / 1024 / 1024).toFixed(1)} MB`));
     }
 
-    const foreign = embeddedForeignSources(path, src, allTracked);
-    if (foreign.length) {
+    const embedded = inlineMapEntries(path, src).filter((e) => !publishedCopy(e, allTracked, src));
+    if (embedded.length) {
       const rule = RULES.find((r) => r.id === 'inline-sourcemap-sources');
       // One finding per embedded source, so removing some and not others is visible.
-      if (rule) for (const src of foreign) findings.push(record(rule, path, 1, src));
+      if (rule) for (const e of embedded) findings.push(record(rule, path, 1, e.source));
+
+      // What the map embeds is scanned like any other text: same rules, same suppression,
+      // the embedded file's own extension deciding text-ness. Findings land on the bundle,
+      // because the bundle is the tracked file doing the publishing.
+      const seenInMaps = new Set();
+      for (const e of embedded) {
+        const pseudo = e.source.replace(/^(?:\.\.\/|\.\/)+/, '');
+        if (!isTextPath(pseudo)) continue;
+        const heavyEntry = e.content.length > CONFIG.maxTextBytes;
+        const applicableToEntry = contentRules.filter((r) => (heavyEntry ? r.heavy : true) && ruleApplies(r, pseudo));
+        if (applicableToEntry.length === 0) continue;
+        matchContent(applicableToEntry.map((rule) => ({ rule, re: compile(rule) })),
+          e.content.split('\n'), path, findings, seenInMaps);
+      }
     }
 
     /* --- content rules --- */
@@ -366,39 +422,7 @@ function scan(paths, allTracked, src) {
     if (text === null) continue;
     const lines = text.split('\n');
 
-    /**
-     * Two passes over the same file.
-     *
-     * The first is line by line, which is what a reader expects. The second joins each run of
-     * consecutive comment lines into one string and matches against that, because prose wraps
-     * and a rule anchored to a line is defeated by a line break — "collapses every user,
-     * project and machine into one\n * run" matched nothing until this existed. Findings are
-     * deduplicated by fingerprint, so a phrase that fits on one line is reported once.
-     */
-    const seen = new Set();
-    const consider = (rule, re, haystack, lineNo) => {
-      re.lastIndex = 0;
-      let m;
-      while ((m = re.exec(haystack)) !== null) {
-        if (m[0] === '') { re.lastIndex += 1; continue; }
-        if (!keepMatch(rule, m[0])) continue;
-        if (suppressed(lines, lineNo - 1, rule.id)) continue;
-        const f = record(rule, path, lineNo, m[0]);
-        if (seen.has(f.fingerprint)) continue;
-        seen.add(f.fingerprint);
-        findings.push(f);
-      }
-    };
-
-    for (let i = 0; i < lines.length; i += 1) {
-      const line = lines[i];
-      if (!line) continue;
-      for (const { rule, re } of compiled) consider(rule, re, line, i + 1);
-    }
-
-    for (const block of commentBlocks(lines)) {
-      for (const { rule, re } of compiled) consider(rule, re, block.text, block.line);
-    }
+    matchContent(compiled, lines, path, findings, new Set());
   }
 
   findings.sort((a, b) => (a.path === b.path ? a.line - b.line : a.path.localeCompare(b.path)));

--- a/.github/scripts/leakcheck.selftest.mjs
+++ b/.github/scripts/leakcheck.selftest.mjs
@@ -51,6 +51,20 @@ const domesticMap = {
   sourcesContent: ['export const ours = 1;'],
   mappings: '',
 };
+/** A foreign source whose embedded text carries a blocking sentence — both must fire. */
+const leakyForeignMap = {
+  version: 3,
+  sources: ['../../../mcp/src/quiet-leak.ts'],
+  sourcesContent: ['export const q = 1; // naming it would let a client write a tenant-wide rule'],
+  mappings: '',
+};
+/** Same basename as a tracked file, different text: a stale copy, not a published one. */
+const staleCopyMap = {
+  version: 3,
+  sources: ['../lib/ours.mjs'],
+  sourcesContent: ['export const ours = 2; // anything above run scope could write a tenant-wide rule'],
+  mappings: '',
+};
 const inline = (m) => `//# sourceMappingURL=data:application/json;base64,${Buffer.from(JSON.stringify(m)).toString('base64')}`;
 
 /** @type {Array<{path:string, body:string|Buffer, expect:string[], quiet?:string[]}>} */
@@ -113,6 +127,22 @@ const CASES = [
     body: `export const ours = 1;\n${inline(domesticMap)}\n`,
     expect: [],
     quiet: ['inline-sourcemap-sources'],
+  },
+  {
+    // The bundle's own text is clean; the leak is a sentence inside the map's
+    // `sourcesContent`, where no line-oriented rule has ever looked. The content rules
+    // must run over what the map embeds, not only over what the file says.
+    path: 'a/leaky-map-bundle.js',
+    body: `export const x = 1;\n${inline(leakyForeignMap)}\n`,
+    expect: ['inline-sourcemap-sources', 'isolation-defect-disclosure'],
+  },
+  {
+    // A stale copy: the map names a file this repository tracks, but embeds text the
+    // tracked file no longer says. Matching by basename alone silenced 36 of these —
+    // the name is not the content, and only the content is what gets published.
+    path: 'a/stale-copy-bundle.js',
+    body: `export const ours = 1;\n${inline(staleCopyMap)}\n`,
+    expect: ['inline-sourcemap-sources', 'isolation-defect-disclosure'],
   },
   {
     // Suppression, placeholders, allowlisted addresses and public vendor examples must not fire.

--- a/.github/workflows/leak-scan.yml
+++ b/.github/workflows/leak-scan.yml
@@ -23,6 +23,9 @@ on:
     branches: ['**']
   pull_request:
   workflow_dispatch:
+  schedule:
+    # Monday, off the whole-hour rush. Weekly is enough for branches nobody is pushing.
+    - cron: '23 6 * * 1'
 
 permissions:
   contents: read
@@ -67,6 +70,40 @@ jobs:
         with:
           sarif_file: leakcheck.sarif
           category: leakcheck
+
+  all-refs:
+    name: every ref, today's rules
+    # A public repository serves every ref it has ever been pushed, not only the one a
+    # workflow just ran on. Branches go quiet, the catalogue keeps improving, and a tree
+    # that passed last year's rules can fail this year's without anyone touching it — the
+    # audit that motivated this job found real exposure only on tips no push had scanned
+    # in months. `--rev` reads trees straight from the object store: one clone, no checkouts.
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: leakcheck --strict over every branch and tag
+        run: |
+          set -uo pipefail
+          dirty=0
+          for ref in $(git for-each-ref --format='%(refname)' refs/remotes/origin refs/tags \
+                       | grep -v '^refs/remotes/origin/HEAD$'); do
+            echo "::group::${ref}"
+            if ! node .github/scripts/leakcheck.mjs --strict --quiet --no-annotations --rev "$ref"; then
+              dirty=$((dirty + 1))
+              echo "::error title=leakcheck all-refs::${ref} carries blocking findings under today's rules"
+            fi
+            echo "::endgroup::"
+          done
+          echo "refs with blocking findings: ${dirty}"
+          exit $((dirty > 0 ? 1 : 0))
 
   llm-review:
     name: model review of the diff

--- a/integrations/claude-code/test/leakcheck.test.mjs
+++ b/integrations/claude-code/test/leakcheck.test.mjs
@@ -186,6 +186,81 @@ test('no shipped bundle embeds source that is not a tracked file in this repo', 
 });
 
 // ---------------------------------------------------------------------------
+// 5. What a sourcemap embeds is held to the same standard as the tree
+// ---------------------------------------------------------------------------
+
+/**
+ * Check 1 asks *which files* a map embeds; this one reads what it embeds. The
+ * two failure modes are different: a map can name only tracked files and still
+ * carry a stale copy of one — text the tree used to say, kept alive base64'd in
+ * an artifact nobody diffs. Checks 2–4 all strip inline maps before scanning
+ * (deliberately — the mapping payload defeats their heuristics), so without
+ * this check the embedded text is scanned by nothing at all.
+ *
+ * The shapes asserted are exactly checks 2–4's, applied to each decoded
+ * `sourcesContent` entry, with the same redaction-demo exemption: an embedded
+ * copy of the redactor legitimately carries credential shapes, because the
+ * tracked original does.
+ */
+test('nothing an inline sourcemap embeds may carry what the tree itself may not', () => {
+  const findings = [];
+  let entriesScanned = 0;
+
+  for (const { rel, text } of corpus()) {
+    if (!/\.(mjs|js)$/.test(rel)) continue;
+
+    for (const match of text.matchAll(INLINE_MAP)) {
+      let map;
+      try {
+        map = JSON.parse(Buffer.from(match[1], 'base64').toString('utf8'));
+      } catch {
+        continue; // undecodable maps are check 1's finding, not this one's
+      }
+
+      const sources = map.sources ?? [];
+      const contents = map.sourcesContent ?? [];
+
+      sources.forEach((source, i) => {
+        const content = contents[i];
+        if (typeof content !== 'string' || content.length === 0) return;
+        entriesScanned += 1;
+
+        const where = (excerpt) => `${rel} (map: ${source}): ${excerpt}`;
+
+        for (const m of content.matchAll(HOME_PATH)) {
+          const who = m[1];
+          if (PLACEHOLDER_HOMES.has(who) || /^[$<{]/.test(who)) continue;
+          findings.push(where(m[0]));
+        }
+        for (const m of content.matchAll(WORKSPACE_CRATE_PATH)) {
+          findings.push(where(`${m[0]}…`));
+        }
+        if (!isRedactionDemo(source)) {
+          for (const [label, pattern] of SECRET_SHAPES) {
+            for (const m of content.matchAll(pattern)) {
+              findings.push(where(`${label} — ${m[0].slice(0, 48)}…`));
+            }
+          }
+        }
+      });
+    }
+  }
+
+  assert.ok(entriesScanned > 0,
+    'No embedded sources were scanned at all. Either the builds stopped inlining\n'
+    + '  sourcesContent or this scan stopped decoding them — and a scan that reads\n'
+    + '  nothing cannot fail.');
+
+  assert.equal(findings.length, 0,
+    `An inline sourcemap embeds text the tree itself would not be allowed to carry.\n\n`
+    + `${report(findings)}\n\n`
+    + '  The bundle diff never showed this — the payload is one base64 line. It is\n'
+    + '  usually a stale embedded copy: the tracked file was cleaned, the bundle was\n'
+    + '  not rebuilt, and the map keeps republishing the old text. Rebuild the bundle\n'
+    + '  (or fix the source and then rebuild); do not exempt it here.');
+});
+
+// ---------------------------------------------------------------------------
 // 2. No tracked file may carry a real home directory
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
**Stacked on #44** — merge that first; GitHub will retarget this to `pre-main` when its branch is deleted. The stacking is load-bearing, not cosmetic: this scanner immediately flags the stale codex-bundle debt `pre-main` carries today (31 blocking `inline-sourcemap-sources` findings), which #44's rebuild clears. On the combined tree: 0 blocking, warnings unchanged at 693.

## Summary
- The leak scanner now runs content rules over every inline sourcemap's `sourcesContent` — the blind spot through which the full private `mcp/src/*` TypeScript reached 22 public branch trees (4,273 findings invisible to the old scanner, per the 2026-08-31 audit).
- The basename shortcut that silenced 36+ stale embedded copies is gone: an embedded source passes only if a tracked file with the same basename carries **identical text**. `.tsx` added to `textExtensions` (`.ts` was already present).
- Every inline map in a file is decoded, not just the last.
- New selftest cases (blocking phrase only in `sourcesContent`; stale tracked-basename copy; clean-map negative) and a fifth repo check: nothing an inline sourcemap embeds may carry what the tree itself may not.
- Weekly `all-refs` job in `leak-scan.yml` (Mon 06:23 UTC + manual dispatch) walks every remote ref and tag under today's rules — it will stay red until the dirty branches in the audit's decision list are dealt with; that is its job.

## Test plan
- [x] Selftest red→green on exactly the two blind spots; `leakcheck.selftest: ok — 14 cases`
- [x] Fifth check seen red against a planted leaky map, then reverted; 5/5 green
- [x] Full suite on the combined tree: 1562/1562
- [x] `leakcheck.mjs` default and `--strict`: exit 0, 0 blocking, 693 warnings (baseline)
- [x] Pre-push gate passed on push (scans with this branch's own sharpened rules)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Se6zGJ7v8gAWQEb2E9SBEm