### PR TITLE
chore: 0.12.5

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "mubit-memory",
       "displayName": "Mubit Memory",
-      "version": "0.12.4",
+      "version": "0.12.5",
       "description": "Persistent, typed, self-improving memory for Claude Code, backed by Mubit.",
       "author": { "name": "Mubit AI", "url": "https://mubit.ai" },
       "source": "./integrations/claude-code",

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ no `npm install` — the bundles ship committed.
 
 | Plugin | Version | Built for |
 | --- | --- | --- |
-| [`mubit-memory`](integrations/claude-code/) | 0.12.4 | [Claude Code](integrations/claude-code/) · [Codex CLI](integrations/codex/) |
+| [`mubit-memory`](integrations/claude-code/) | 0.12.5 | [Claude Code](integrations/claude-code/) · [Codex CLI](integrations/codex/) |
 
 You need two values before you start:
 

--- a/integrations/claude-code/.claude-plugin/plugin.json
+++ b/integrations/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mubit-memory",
   "displayName": "Mubit Memory",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "description": "Persistent, typed, self-improving memory for Claude Code, backed by Mubit. Captures work involuntarily, recalls relevant lessons before every prompt, and attributes outcomes so memory improves with use.",
   "author": { "name": "Mubit AI", "url": "https://mubit.ai" },
   "homepage": "https://docs.mubit.ai/integrations/claude-code",

--- a/integrations/claude-code/mcp/dist/index.js
+++ b/integrations/claude-code/mcp/dist/index.js
@@ -2447,7 +2447,7 @@ var BRIDGED = [
   ["MUBIT_CC_DATA_DIR", "CLAUDE_PLUGIN_DATA"]
 ];
 var UNEXPANDED = /^\$\{[A-Za-z_][A-Za-z0-9_]*\}$/;
-var SERVER_VERSION = true ? "0.12.4" : "";
+var SERVER_VERSION = true ? "0.12.5" : "";
 if (prepare(process.env)) {
   await import("./server.js");
 }

--- a/integrations/claude-code/package-lock.json
+++ b/integrations/claude-code/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mubit-ai/claude-code-plugin",
-  "version": "0.12.0",
+  "version": "0.12.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mubit-ai/claude-code-plugin",
-      "version": "0.12.0",
+      "version": "0.12.5",
       "devDependencies": {
         "@mubit-ai/mcp": "file:../mcp",
         "esbuild": "^0.28.0"

--- a/integrations/claude-code/package.json
+++ b/integrations/claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mubit-ai/claude-code-plugin",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "type": "module",
   "description": "Mubit memory plugin for Claude Code — involuntary capture, pre-prompt recall, and outcome attribution.",
   "license": "Apache-2.0",

--- a/integrations/codex/.codex-plugin/plugin.json
+++ b/integrations/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mubit-memory",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "description": "Persistent, typed, self-improving memory for OpenAI Codex, backed by Mubit. Captures work involuntarily, recalls relevant lessons before every prompt, and attributes outcomes so memory improves with use. Shares one memory with the Claude Code plugin when both run in the same directory.",
   "author": {
     "name": "Mubit AI",

--- a/integrations/codex/mcp/dist/index.js
+++ b/integrations/codex/mcp/dist/index.js
@@ -2447,7 +2447,7 @@ var BRIDGED = [
   ["MUBIT_CC_DATA_DIR", "CLAUDE_PLUGIN_DATA"]
 ];
 var UNEXPANDED = /^\$\{[A-Za-z_][A-Za-z0-9_]*\}$/;
-var SERVER_VERSION = true ? "0.12.4" : "";
+var SERVER_VERSION = true ? "0.12.5" : "";
 if (prepare(process.env)) {
   await import("./server.js");
 }

--- a/integrations/codex/package.json
+++ b/integrations/codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mubit-ai/codex-plugin",
-  "version": "0.12.4",
+  "version": "0.12.5",
   "type": "module",
   "description": "Mubit memory plugin for OpenAI Codex CLI — involuntary capture, pre-prompt recall, and outcome attribution.",
   "engines": { "node": ">=20.0.0" },


### PR DESCRIPTION
Moves the source branch to 0.12.5 so it does not sit at 0.12.4 while `main` publishes 0.12.5. The release cut (PR to `main`) is separate and stacks on this content.

## The nine sites

`manifests.test.mjs` says a bump touches four files (§12.7) and a `grep` finds eight. Both undercount:

| | |
| --- | --- |
| edited | `.claude-plugin/marketplace.json`, `README.md`, both `plugin.json`, both `package.json`, `package-lock.json` |
| rebuilt | `integrations/{claude-code,codex}/mcp/dist/index.js` — the version is inlined at build time via `__MUBIT_MCP_VERSION__`, so it moves by rebuild, and `serverInfo.version` misreports until it does |

`mcp/dist/server.js` carries no version of its own (the launcher hands it one), so `MUBIT_CC_BUILD_SKIP_SERVER=1` — required in this checkout, which has no `../mcp` — costs nothing here.

**`package-lock.json` had drifted to 0.12.0**: it missed the 0.12.4 bump entirely, because nothing asserts it — the lockstep test reads `plugin.json`, `package.json` and the marketplace entry, and the lockfile is curated out of the published tree. Its two own-name fields move here; the `../mcp` sibling entry is deliberately untouched, being a different package on a separate version line.

## Verification
- [x] No `0.12.4` survives anywhere in the tracked tree **with inline sourcemaps decoded** — `sourcesContent` included, where grep is blind
- [x] `npm test` and `MUBIT_CC_TEST_TARGET=dist npm test`: 1562/1562 claude-code, 366/366 codex
- [x] 65 bundles byte-identical across a second rebuild
- [x] `claude plugin validate` passes on the plugin; the marketplace's `contextCost` warning is pre-existing
- [x] `leakcheck` exits 0; pre-push gate passed on push

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Se6zGJ7v8gAWQEb2E9SBEm