### PR TITLE
feat(scripts): measure what memory actually cost, from the transcripts; 0.13.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "mubit-memory",
       "displayName": "Mubit Memory",
-      "version": "0.12.6",
+      "version": "0.13.0",
       "description": "Persistent, typed, self-improving memory for Claude Code, backed by Mubit.",
       "author": { "name": "Mubit AI", "url": "https://mubit.ai" },
       "source": "./integrations/claude-code",

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ no `npm install` — the bundles ship committed.
 
 | Plugin | Version | Built for |
 | --- | --- | --- |
-| [`mubit-memory`](integrations/claude-code/) | 0.12.6 | [Claude Code](integrations/claude-code/) · [Codex CLI](integrations/codex/) |
+| [`mubit-memory`](integrations/claude-code/) | 0.13.0 | [Claude Code](integrations/claude-code/) · [Codex CLI](integrations/codex/) |
 
 You need two values before you start:
 

--- a/integrations/claude-code/.claude-plugin/plugin.json
+++ b/integrations/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mubit-memory",
   "displayName": "Mubit Memory",
-  "version": "0.12.6",
+  "version": "0.13.0",
   "description": "Persistent, typed, self-improving memory for Claude Code, backed by Mubit. Captures work involuntarily, recalls relevant lessons before every prompt, and attributes outcomes so memory improves with use.",
   "author": { "name": "Mubit AI", "url": "https://mubit.ai" },
   "homepage": "https://docs.mubit.ai/integrations/claude-code",

--- a/integrations/claude-code/docs/user-guide.md
+++ b/integrations/claude-code/docs/user-guide.md
@@ -496,6 +496,11 @@ cut. The untouched result is saved under the plugin's data directory, and the no
 of the result names the file, so the rest costs nothing unless the model reads it. `0` returns
 the raw result.
 
+To see what memory actually cost on this machine — every hook injection and every tool result,
+per event and per session, read off the transcripts Claude Code keeps — run
+`node scripts/measure-context-usage.mjs` from the plugin directory. It prints counts and
+sizes only, never content.
+
 ### Keep this on
 
 `reflectOnEnd`, default `true`. It is the only path that promotes a lesson beyond its own run.

--- a/integrations/claude-code/mcp/dist/index.js
+++ b/integrations/claude-code/mcp/dist/index.js
@@ -2911,7 +2911,7 @@ var BRIDGED = [
   ["MUBIT_CC_DATA_DIR", "CLAUDE_PLUGIN_DATA"]
 ];
 var UNEXPANDED = /^\$\{[A-Za-z_][A-Za-z0-9_]*\}$/;
-var SERVER_VERSION = true ? "0.12.6" : "";
+var SERVER_VERSION = true ? "0.13.0" : "";
 if (prepare(process.env)) {
   await import("./server.js");
 }

--- a/integrations/claude-code/package-lock.json
+++ b/integrations/claude-code/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mubit-ai/claude-code-plugin",
-  "version": "0.12.6",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mubit-ai/claude-code-plugin",
-      "version": "0.12.6",
+      "version": "0.13.0",
       "license": "Apache-2.0",
       "devDependencies": {
         "@mubit-ai/mcp": "file:../mcp",

--- a/integrations/claude-code/package.json
+++ b/integrations/claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mubit-ai/claude-code-plugin",
-  "version": "0.12.6",
+  "version": "0.13.0",
   "type": "module",
   "description": "Mubit memory plugin for Claude Code — involuntary capture, pre-prompt recall, and outcome attribution.",
   "license": "Apache-2.0",

--- a/integrations/claude-code/scripts/measure-context-usage.mjs
+++ b/integrations/claude-code/scripts/measure-context-usage.mjs
@@ -1,0 +1,356 @@
+#!/usr/bin/env node
+// @ts-check
+/**
+ * Measure what the plugin actually put in front of the model, from the transcripts on this
+ * machine.
+ *
+ * `measure-context-cost.mjs` measures the always-loaded surface: what a session pays before
+ * the model does anything. This measures the other half — what the hooks injected and what
+ * the MCP tools answered, per event and per session — which is where the cost that grows with
+ * a session lives. The two numbers answer different questions and neither stands in for the
+ * other: over fourteen days of real sessions the static surface came to ~1.5k tokens a session
+ * under tool search, while a single tool result reached ~12k.
+ *
+ *   node scripts/measure-context-usage.mjs                 # last 14 days, ~/.claude/projects
+ *   node scripts/measure-context-usage.mjs --days 30
+ *   node scripts/measure-context-usage.mjs --projects <dir>  # another transcript root
+ *   node scripts/measure-context-usage.mjs --json
+ *
+ * **What is counted.** Claude Code stores a hook's `additionalContext` in the transcript as an
+ * attachment line, and it stays in history until the next compaction — so an injection is
+ * paid on the turn it lands and again on every turn after it. Each attachment whose text
+ * mentions Mubit is attributed to the hook that produced it (the attachment names it), and
+ * every result of a `mubit_*` tool call is attributed to its tool. The estimate is the
+ * plugin's own (`lib/assemble.mjs`), so the numbers here compare with the budgets in the
+ * manifest rather than with a tokenizer.
+ *
+ * **What is printed.** Counts and sizes, never content. No path below the transcript root is
+ * printed either: a project directory name is a project directory name.
+ *
+ * Zero dependencies, Node >= 20, read-only.
+ */
+
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { estimateTokens } from '../lib/assemble.mjs';
+
+const PLUGIN_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const DEFAULT_DAYS = 14;
+const TOOL_PREFIX = 'mcp__plugin_mubit-memory_mubit__';
+
+/** The attachment types that carry the always-loaded listings. Counted, not sized: `measure-context-cost.mjs` sizes them. */
+const LISTING_TYPES = new Set(['skill_listing', 'mcp_instructions_delta', 'deferred_tools_delta', 'agent_listing_delta']);
+
+/**
+ * What the plugin's own hooks put at the head of what they emit. Another hook's output that
+ * merely talks about Mubit — a session working on this very plugin produces plenty — carries
+ * none of these and is not ours to count.
+ */
+const MARKERS = ['<mubit-memory ', '<mubit-resume ', '<mubit-rules ', '# Mubit memory'];
+
+// ---------------------------------------------------------------------------
+// argv
+// ---------------------------------------------------------------------------
+
+/**
+ * @param {string[]} argv
+ * @returns {{days: number, projects: string, json: boolean, help: boolean, error: string}}
+ */
+export function parseArgs(argv = []) {
+  const out = { days: DEFAULT_DAYS, projects: join(homedir(), '.claude', 'projects'), json: false, help: false, error: '' };
+  for (let i = 0; i < argv.length; i += 1) {
+    const a = String(argv[i]);
+    if (a === '--json') out.json = true;
+    else if (a === '--help' || a === '-h') out.help = true;
+    else if (a === '--days' || a === '--projects') {
+      const v = argv[i + 1];
+      if (v === undefined) { out.error = `${a} needs a value`; return out; }
+      i += 1;
+      if (a === '--days') {
+        out.days = Number(v);
+        if (!Number.isInteger(out.days) || out.days < 1) { out.error = '--days must be a whole number of days'; return out; }
+      } else {
+        out.projects = resolve(String(v));
+      }
+    } else { out.error = `unknown option ${a}`; return out; }
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Scanning
+// ---------------------------------------------------------------------------
+
+/**
+ * @typedef {object} Series
+ * @property {number} count
+ * @property {number} total
+ * @property {number[]} sizes
+ */
+
+/**
+ * @typedef {object} FileStats
+ * @property {boolean} subagent
+ * @property {number} prompts
+ * @property {boolean} loaded         a Mubit listing attachment appeared — the plugin was on
+ * @property {Record<string, number[]>} injected   tokens per fire, by source
+ * @property {Record<string, number[]>} tools    result sizes by tool
+ */
+
+/**
+ * Attribute one transcript. Pure: takes the file's text, returns what the plugin cost in it.
+ *
+ * @param {string} text
+ * @param {{subagent?: boolean}} [opts]
+ * @returns {FileStats}
+ */
+export function analyseTranscript(text, opts = {}) {
+  /** @type {FileStats} */
+  const s = { subagent: opts.subagent === true, prompts: 0, loaded: false, injected: {}, tools: {} };
+  /** @type {Map<string, string>} */
+  const pending = new Map();
+  for (const line of String(text ?? '').split('\n')) {
+    if (!line) continue;
+    /** @type {any} */
+    let o;
+    try { o = JSON.parse(line); } catch { continue; }
+    if (!o || typeof o !== 'object') continue;
+
+    if (o.type === 'assistant') {
+      for (const b of blocks(o)) {
+        if (b.type === 'tool_use' && typeof b.name === 'string' && b.name.startsWith(TOOL_PREFIX)) {
+          pending.set(String(b.id), b.name.slice(TOOL_PREFIX.length));
+        }
+      }
+      continue;
+    }
+
+    if (o.type === 'user') {
+      const c = o.message?.content;
+      const list = Array.isArray(c) ? c : [];
+      const hasResult = list.some((b) => b && b.type === 'tool_result');
+      const hasText = typeof c === 'string' || list.some((b) => b && b.type === 'text');
+      if (hasText && !hasResult && o.isMeta !== true) s.prompts += 1;
+      for (const b of list) {
+        if (!b || b.type !== 'tool_result' || !pending.has(String(b.tool_use_id))) continue;
+        const name = pending.get(String(b.tool_use_id)) ?? '';
+        pending.delete(String(b.tool_use_id));
+        const body = typeof b.content === 'string' ? b.content
+          : Array.isArray(b.content) ? b.content.map((x) => (x && typeof x.text === 'string' ? x.text : '')).join('\n')
+            : JSON.stringify(b.content ?? '');
+        (s.tools[name] ??= []).push(estimateTokens(body));
+      }
+      continue;
+    }
+
+    if (o.type !== 'attachment' || !o.attachment || typeof o.attachment !== 'object') continue;
+    const a = o.attachment;
+    if (LISTING_TYPES.has(String(a.type))) {
+      if (/mubit/i.test(JSON.stringify(a))) s.loaded = true;
+      continue;
+    }
+    if (a.type !== 'hook_additional_context') continue;
+    const content = Array.isArray(a.content) ? a.content.map(String).join('\n') : String(a.content ?? '');
+    if (!MARKERS.some((m) => content.includes(m))) continue;
+    const event = String(a.hookEvent ?? a.hookName ?? '');
+    for (const part of split(content)) {
+      const source = sourceOf(event, part, s.subagent);
+      (s.injected[source] ??= []).push(estimateTokens(part));
+    }
+  }
+  return s;
+}
+
+/**
+ * The first prompt of a resumed session carries the briefing and that turn's recall in one
+ * output, the briefing above the `<mubit-memory>` envelope. They are two costs with two
+ * dials, so they are counted apart.
+ * @param {string} content
+ * @returns {string[]}
+ */
+function split(content) {
+  const at = content.indexOf('<mubit-memory ');
+  if (at <= 0 || !content.includes('<mubit-resume ')) return [content];
+  return [content.slice(0, at), content.slice(at)];
+}
+
+/**
+ * Which of the plugin's injections this is. The hook event is the primary key; the markers
+ * the hooks themselves emit split one event's several outputs.
+ * @param {string} event
+ * @param {string} content
+ * @param {boolean} subagent
+ */
+function sourceOf(event, content, subagent) {
+  const ev = event.split(':')[0];
+  if (ev === 'SessionStart') {
+    return /# Mubit memory is active/.test(content) ? 'SessionStart steer block' : 'SessionStart notice (unconfigured, offline, auth)';
+  }
+  if (ev === 'UserPromptSubmit') {
+    if (/<mubit-resume /.test(content)) return 'UserPromptSubmit resume briefing';
+    if (/<mubit-memory [^>]*sources="0"/.test(content)) return 'UserPromptSubmit pins only';
+    return 'UserPromptSubmit recall';
+  }
+  if (ev === 'SubagentStart' || subagent) return 'SubagentStart recall';
+  if (ev === 'PreToolUse') return 'PreToolUse warning';
+  return ev ? `${ev} (other)` : 'unknown hook';
+}
+
+/** @param {any} o */
+function blocks(o) {
+  const c = o?.message?.content;
+  return Array.isArray(c) ? c.filter((b) => b && typeof b === 'object') : [];
+}
+
+/**
+ * Every `.jsonl` under `root` modified since `sinceMs`, with whether it is a subagent transcript.
+ * @param {string} root
+ * @param {number} sinceMs
+ * @returns {Array<{path: string, subagent: boolean}>}
+ */
+export function listTranscripts(root, sinceMs) {
+  /** @type {Array<{path: string, subagent: boolean}>} */
+  const out = [];
+  const walk = (dir) => {
+    let entries = [];
+    try { entries = readdirSync(dir, { withFileTypes: true }); } catch { return; }
+    for (const e of entries) {
+      const p = join(dir, e.name);
+      if (e.isDirectory()) walk(p);
+      else if (e.isFile() && e.name.endsWith('.jsonl')) {
+        try { if (statSync(p).mtimeMs >= sinceMs) out.push({ path: p, subagent: p.includes(`${'/'}subagents${'/'}`) }); } catch { /* raced */ }
+      }
+    }
+  };
+  walk(root);
+  return out;
+}
+
+/**
+ * @typedef {object} Report
+ * @property {number} days
+ * @property {number} files
+ * @property {number} sessions          main transcripts with at least one prompt
+ * @property {number} loadedSessions    of those, with the plugin's listings present
+ * @property {number} prompts
+ * @property {Record<string, Series>} injected
+ * @property {Record<string, Series>} tools
+ * @property {number[]} perSession      tokens of everything above, per main session
+ * @property {{value: number, measuredAt: string}|null} declared   scripts/context-cost.json
+ */
+
+/**
+ * @param {string} root
+ * @param {{days?: number, now?: number}} [opts]
+ * @returns {Report}
+ */
+export function measure(root, opts = {}) {
+  const days = opts.days ?? DEFAULT_DAYS;
+  const now = opts.now ?? Date.now();
+  const files = listTranscripts(root, now - days * 86_400_000);
+  /** @type {Report} */
+  const r = { days, files: files.length, sessions: 0, loadedSessions: 0, prompts: 0, injected: {}, tools: {}, perSession: [], declared: declared() };
+  const add = (table, key, n) => {
+    const s = table[key] ??= { count: 0, total: 0, sizes: [] };
+    s.count += 1; s.total += n; s.sizes.push(n);
+  };
+  for (const f of files) {
+    let text;
+    try { text = readFileSync(f.path, 'utf8'); } catch { continue; }
+    const s = analyseTranscript(text, { subagent: f.subagent });
+    let session = 0;
+    for (const [k, sizes] of Object.entries(s.injected)) for (const n of sizes) { add(r.injected, k, n); session += n; }
+    for (const [name, sizes] of Object.entries(s.tools)) for (const n of sizes) { add(r.tools, name, n); session += n; }
+    if (!f.subagent && s.prompts > 0) {
+      r.sessions += 1;
+      r.prompts += s.prompts;
+      if (s.loaded) r.loadedSessions += 1;
+      r.perSession.push(session);
+    }
+  }
+  return r;
+}
+
+function declared() {
+  try {
+    const stamp = JSON.parse(readFileSync(join(PLUGIN_ROOT, 'scripts', 'context-cost.json'), 'utf8'));
+    return { value: Number(stamp.value) || 0, measuredAt: String(stamp.measuredAt ?? '') };
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// The report
+// ---------------------------------------------------------------------------
+
+/** @param {number[]} a @param {number} p */
+function pct(a, p) {
+  if (!a.length) return 0;
+  const b = [...a].sort((x, y) => x - y);
+  return b[Math.min(b.length - 1, Math.floor(p * b.length))];
+}
+
+/** @param {Report} r */
+export function render(r) {
+  const n = (v) => String(v).replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+  const lines = [];
+  lines.push(`Mubit context usage — last ${r.days} days: ${n(r.sessions)} sessions (${n(r.loadedSessions)} with the plugin loaded), ${n(r.prompts)} prompts, ${n(r.files)} transcripts`);
+  lines.push('');
+  if (r.declared) {
+    lines.push(`Always-loaded, per session: ${n(r.declared.value)} tokens declared (scripts/context-cost.json, ${r.declared.measuredAt.slice(0, 10)}); tool schemas are deferred under tool search.`);
+    lines.push('');
+  }
+  const table = (title, unit, rows) => {
+    lines.push(`${title.padEnd(48)} ${unit.padStart(6)} ${'p50'.padStart(7)} ${'p90'.padStart(7)} ${'max'.padStart(7)} ${'total'.padStart(9)}`);
+    for (const [k, s] of rows) {
+      lines.push(`  ${k.padEnd(46)} ${n(s.count).padStart(6)} ${n(pct(s.sizes, 0.5)).padStart(7)} ${n(pct(s.sizes, 0.9)).padStart(7)} ${n(pct(s.sizes, 1)).padStart(7)} ${n(s.total).padStart(9)}`);
+    }
+    if (!rows.length) lines.push('  (none)');
+    lines.push('');
+  };
+  const byTotal = (t) => Object.entries(t).sort((a, b) => b[1].total - a[1].total);
+  table('Injected by hooks (tokens)', 'fires', byTotal(r.injected));
+  table('MCP tool results (tokens)', 'calls', byTotal(r.tools));
+  const injectedTotal = Object.values(r.injected).reduce((a, s) => a + s.total, 0);
+  const toolTotal = Object.values(r.tools).reduce((a, s) => a + s.total, 0);
+  lines.push(`Per main session, everything above: p50 ${n(pct(r.perSession, 0.5))}, p90 ${n(pct(r.perSession, 0.9))}, max ${n(pct(r.perSession, 1))} tokens; ${n(injectedTotal)} injected and ${n(toolTotal)} in tool results over the period.`);
+  lines.push('An injection stays in history until the next compaction, so each is paid again on every later turn.');
+  return `${lines.join('\n')}\n`;
+}
+
+// ---------------------------------------------------------------------------
+// Entry
+// ---------------------------------------------------------------------------
+
+/**
+ * @param {string[]} [argv]
+ * @param {{stdout?: (s: string) => void, stderr?: (s: string) => void}} [deps]
+ */
+export async function main(argv = process.argv.slice(2), deps = {}) {
+  const stdout = deps.stdout ?? ((s) => process.stdout.write(s));
+  const stderr = deps.stderr ?? ((s) => process.stderr.write(s));
+  const args = parseArgs(argv);
+  const usage = 'usage: measure-context-usage [--days N] [--projects <dir>] [--json]\n';
+  if (args.error) { stderr(`${args.error}\n${usage}`); return 2; }
+  if (args.help) { stdout(usage); return 0; }
+  const r = measure(args.projects, { days: args.days });
+  if (args.json) {
+    const strip = (t) => Object.fromEntries(Object.entries(t).map(([k, s]) => [k, { count: s.count, total: s.total, p50: pct(s.sizes, 0.5), p90: pct(s.sizes, 0.9), max: pct(s.sizes, 1) }]));
+    stdout(`${JSON.stringify({ ...r, injected: strip(r.injected), tools: strip(r.tools), perSession: { p50: pct(r.perSession, 0.5), p90: pct(r.perSession, 0.9), max: pct(r.perSession, 1) } }, null, 2)}\n`);
+  } else {
+    stdout(render(r));
+  }
+  return 0;
+}
+
+const selfPath = fileURLToPath(import.meta.url);
+if (process.argv[1] && resolve(process.argv[1]) === selfPath) {
+  process.exitCode = await main().catch((err) => {
+    process.stderr.write(`measure-context-usage: ${err instanceof Error ? err.message : String(err)}\n`);
+    return 1;
+  });
+}

--- a/integrations/claude-code/test/measure-context-usage.test.mjs
+++ b/integrations/claude-code/test/measure-context-usage.test.mjs
@@ -1,0 +1,135 @@
+// @ts-check
+/**
+ * `scripts/measure-context-usage.mjs` — what the plugin actually cost, read off the transcripts.
+ *
+ * The static surface is measured by `measure-context-cost.mjs` and declared in the manifest.
+ * This script measures the half that grows with a session — hook injections and tool results —
+ * and it is the number every change in this series claims to move. So it has to attribute
+ * correctly: an injection to the hook that made it, a tool result to its tool, a prompt only
+ * when a person typed one, and nothing from another plugin's hooks.
+ *
+ * Transcripts are synthesised here in the shape Claude Code writes them: one JSON object per
+ * line, hook output as an `attachment` line, tool results in the user message that follows
+ * the call.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { mod, tempDir } from './helpers/harness.mjs';
+
+const M = () => mod('scripts/measure-context-usage.mjs');
+
+const line = (o) => `${JSON.stringify(o)}\n`;
+const prompt = (text) => line({ type: 'user', message: { role: 'user', content: text } });
+const hook = (event, content) => line({ type: 'attachment', attachment: { type: 'hook_additional_context', hookName: event, hookEvent: event, content: [content] } });
+const listing = () => line({ type: 'attachment', attachment: { type: 'skill_listing', content: '- mubit-memory:recall: search memory' } });
+const call = (id, tool, args = {}) => line({ type: 'assistant', message: { role: 'assistant', content: [{ type: 'tool_use', id, name: `mcp__plugin_mubit-memory_mubit__${tool}`, input: args }] } });
+const result = (id, text) => line({ type: 'user', message: { role: 'user', content: [{ type: 'tool_result', tool_use_id: id, content: [{ type: 'text', text }] }] } });
+
+const STEER = '# Mubit memory is active\n\nRun: cc-test (hosted)\n';
+const RECALL = '<mubit-memory run="cc-test" sources="2" tokens="60">\n## Lessons\n- Poll the job.\n- Never force-push.\n</mubit-memory>';
+const PINS_ONLY = '<mubit-memory run="cc-test" sources="0" tokens="0" pins="1">\n- pinned: stay on main\n</mubit-memory>';
+const RESUME = '<mubit-resume run="cc-test" sources="3" tokens="200">\nWhere we were: mid-migration.\n</mubit-resume>';
+
+/** A main-conversation transcript with two prompts, a steer, two recalls, a pins-only turn, a resume and two tool calls. */
+function mainTranscript() {
+  return [
+    listing(),
+    hook('SessionStart:startup', STEER),
+    prompt('first'),
+    hook('UserPromptSubmit', RESUME + '\n' + RECALL),
+    call('t1', 'mubit_lessons', { limit: 30 }),
+    result('t1', 'x'.repeat(4000)),
+    prompt('second'),
+    hook('UserPromptSubmit', RECALL),
+    hook('UserPromptSubmit', PINS_ONLY),
+    call('t2', 'mubit_recall', { query: 'q' }),
+    result('t2', 'y'.repeat(800)),
+    // Another plugin's hook output: never attributed, even when it talks about Mubit, because
+    // it carries none of the markers our hooks emit.
+    hook('UserPromptSubmit', 'some other plugin says hello'),
+    hook('UserPromptSubmit', 'a note from a different hook about the mubit plugin, 400 chars of it '.repeat(6)),
+    // A tool result from a tool that is not ours.
+    line({ type: 'assistant', message: { role: 'assistant', content: [{ type: 'tool_use', id: 't3', name: 'Read', input: {} }] } }),
+    result('t3', 'z'.repeat(9000)),
+  ].join('');
+}
+
+function subagentTranscript() {
+  return [
+    hook('SubagentStart:Explore', RECALL),
+    prompt('do the thing'),
+  ].join('');
+}
+
+test('analyseTranscript attributes each injection to its hook and each result to its tool', async () => {
+  const { analyseTranscript } = await M();
+  const s = analyseTranscript(mainTranscript());
+
+  assert.equal(s.prompts, 2, 'only the two typed prompts count; tool results are user-role too');
+  assert.equal(s.loaded, true, 'a Mubit skill listing means the plugin was on');
+  assert.deepEqual(Object.keys(s.injected).sort(), [
+    'SessionStart steer block', 'UserPromptSubmit pins only', 'UserPromptSubmit recall', 'UserPromptSubmit resume briefing',
+  ]);
+  assert.equal(s.injected['UserPromptSubmit recall'].length, 2, 'two recalls, one of them split off a briefing');
+  assert.equal(s.injected['UserPromptSubmit resume briefing'].length, 1);
+  assert.ok(s.injected['UserPromptSubmit recall'][0] > s.injected['UserPromptSubmit pins only'][0]);
+  assert.deepEqual(Object.keys(s.tools).sort(), ['mubit_lessons', 'mubit_recall']);
+  assert.equal(s.tools.mubit_lessons[0], 1000, 'a 4000-char result is 1000 estimated tokens');
+  assert.equal(s.tools.mubit_recall[0], 200);
+});
+
+test('a subagent transcript is attributed to SubagentStart', async () => {
+  const { analyseTranscript } = await M();
+  const s = analyseTranscript(subagentTranscript(), { subagent: true });
+  assert.deepEqual(Object.keys(s.injected), ['SubagentStart recall']);
+  assert.equal(s.subagent, true);
+});
+
+test('measure walks the root, keeps subagents out of the session count, and reports per-session totals', async () => {
+  const { measure, render } = await M();
+  const root = tempDir('mubit-usage-');
+  const proj = join(root, '-Users-someone-project');
+  mkdirSync(join(proj, 'abc', 'subagents'), { recursive: true });
+  writeFileSync(join(proj, 'abc.jsonl'), mainTranscript());
+  writeFileSync(join(proj, 'abc', 'subagents', 'agent-1.jsonl'), subagentTranscript());
+  writeFileSync(join(proj, 'empty.jsonl'), listing());
+
+  const r = measure(root, { days: 1 });
+  assert.equal(r.files, 3);
+  assert.equal(r.sessions, 1, 'a transcript with no prompt is not a session, and a subagent is not one either');
+  assert.equal(r.loadedSessions, 1);
+  assert.equal(r.prompts, 2);
+  assert.equal(r.injected['UserPromptSubmit recall'].count, 2);
+  assert.equal(r.injected['SubagentStart recall'].count, 1);
+  assert.equal(r.tools.mubit_lessons.total, 1000);
+  assert.equal(r.perSession.length, 1);
+  const expected = Object.values(r.injected).filter((_, i, all) => true).reduce((a, s) => a + s.total, 0)
+    - r.injected['SubagentStart recall'].total + r.tools.mubit_lessons.total + r.tools.mubit_recall.total;
+  assert.equal(r.perSession[0], expected, 'the per-session total is the main transcript\'s injections plus its tool results');
+
+  const text = render(r);
+  assert.match(text, /1 sessions \(1 with the plugin loaded\), 2 prompts, 3 transcripts/);
+  assert.match(text, /mubit_lessons\s+1\s+1,000\s+1,000\s+1,000\s+1,000/);
+  assert.match(text, /UserPromptSubmit recall\s+2\s+/);
+  assert.ok(!text.includes('someone-project'), 'no path below the root is printed');
+  assert.ok(!text.includes('Poll the job'), 'no content is printed');
+});
+
+test('main: bad flags exit 2, --json is machine-readable', async () => {
+  const { main } = await M();
+  const root = tempDir('mubit-usage-empty-');
+  let out = ''; let err = '';
+  const deps = { stdout: (s) => { out += s; }, stderr: (s) => { err += s; } };
+  assert.equal(await main(['--nope'], deps), 2);
+  assert.match(err, /usage:/);
+  assert.equal(await main(['--days', '0'], deps), 2);
+  out = '';
+  assert.equal(await main(['--projects', root, '--json'], deps), 0);
+  const json = JSON.parse(out);
+  assert.equal(json.sessions, 0);
+  assert.deepEqual(json.perSession, { p50: 0, p90: 0, max: 0 });
+});

--- a/integrations/codex/.codex-plugin/plugin.json
+++ b/integrations/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mubit-memory",
-  "version": "0.12.6",
+  "version": "0.13.0",
   "description": "Persistent, typed, self-improving memory for OpenAI Codex, backed by Mubit. Captures work involuntarily, recalls relevant lessons before every prompt, and attributes outcomes so memory improves with use. Shares one memory with the Claude Code plugin when both run in the same directory.",
   "author": {
     "name": "Mubit AI",

--- a/integrations/codex/mcp/dist/index.js
+++ b/integrations/codex/mcp/dist/index.js
@@ -2911,7 +2911,7 @@ var BRIDGED = [
   ["MUBIT_CC_DATA_DIR", "CLAUDE_PLUGIN_DATA"]
 ];
 var UNEXPANDED = /^\$\{[A-Za-z_][A-Za-z0-9_]*\}$/;
-var SERVER_VERSION = true ? "0.12.6" : "";
+var SERVER_VERSION = true ? "0.13.0" : "";
 if (prepare(process.env)) {
   await import("./server.js");
 }

--- a/integrations/codex/package.json
+++ b/integrations/codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mubit-ai/codex-plugin",
-  "version": "0.12.6",
+  "version": "0.13.0",
   "type": "module",
   "description": "Mubit memory plugin for OpenAI Codex CLI — involuntary capture, pre-prompt recall, and outcome attribution.",
   "engines": { "node": ">=20.0.0" },


### PR DESCRIPTION
## Summary
- New `scripts/measure-context-usage.mjs`: reads the transcripts Claude Code keeps and reports every hook injection and every `mubit_*` tool result, attributed to the hook or tool that produced it, per fire and per main session, with p50/p90/max and totals. Counts and sizes only, never content or paths. This is the dynamic half of the cost picture; `measure-context-cost.mjs` remains the static half.
- Attribution is by the markers the plugin's own hooks emit, so another plugin's hook output that merely mentions Mubit is not counted; a resumed session's first turn is split into briefing and recall.
- Version bumped to 0.13.0 in every manifest and bundles rebuilt so the inlined version matches. The user guide points at the new script.

On this machine, last 14 days, before any of this series is installed: recall injections p50 197 / p90 1,060 / max 1,457 tokens; steer block p50 129 over 189 fires; `mubit_lessons` results p90 6,581 / max 10,530; per session p50 127 / p90 1,483 / max 17,785.

Stacked on #53 (base `feat/context-cost-listing`). Last of four PRs from the context-cost work.

## Test plan
- [x] New `test/measure-context-usage.test.mjs`: attribution per hook and per tool on a synthesised transcript, the subagent split, the per-session total, the report's shape, no content or path leakage, exit codes and `--json`
- [x] claude-code: `npm test` and `npm run test:dist` 1625/1625; `node scripts/verify-manifests.mjs` passes; the version tests pass against the rebuilt bundles
- [x] codex: `npm test` 373/373
- [x] `node .github/scripts/leakcheck.mjs --strict` exits 0; pre-push gate passed
- [x] Ran the script against this machine's real transcripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UYrLxzR2nxATbZeJjMvHiZ