### PR TITLE
chore: 0.13.2, and close the symlink hole in the leak gate

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -7,7 +7,7 @@
     {
       "name": "mubit-memory",
       "displayName": "Mubit Memory",
-      "version": "0.13.1",
+      "version": "0.13.2",
       "description": "Persistent, typed, self-improving memory for Claude Code, backed by Mubit.",
       "author": { "name": "Mubit AI", "url": "https://mubit.ai" },
       "source": "./integrations/claude-code",

--- a/.github/scripts/leakcheck.mjs
+++ b/.github/scripts/leakcheck.mjs
@@ -122,6 +122,10 @@ function source(rev) {
         { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 }).split('\0').filter(Boolean),
       size: (p) => { try { return statSync(join(REPO, p)).size; } catch { return -1; } },
       read: (p) => { try { return readFileSync(join(REPO, p), 'utf8'); } catch { return null; } },
+      links: () => symlinkRows(
+        execFileSync('git', ['-C', REPO, 'ls-files', '-s', '-z'],
+          { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 }), 1,
+        (sha) => execFileSync('git', ['-C', REPO, 'cat-file', 'blob', sha], { encoding: 'utf8' })),
     };
   }
   const git = (args, enc) => execFileSync('git', ['-C', REPO, ...args],
@@ -130,7 +134,33 @@ function source(rev) {
     list: () => git(['ls-tree', '-r', '-z', '--name-only', rev], 'utf8').split('\0').filter(Boolean),
     size: (p) => { try { return Number(git(['cat-file', '-s', `${rev}:${p}`], 'utf8').trim()); } catch { return -1; } },
     read: (p) => { try { return git(['show', `${rev}:${p}`], 'utf8'); } catch { return null; } },
+    links: () => symlinkRows(git(['ls-tree', '-r', '-z', rev], 'utf8'), 2,
+      (sha) => git(['cat-file', 'blob', sha], 'utf8')),
   };
+}
+
+/**
+ * The symlinks in a listing, paired with the path each one points at.
+ *
+ * A symlink is published as a blob whose whole content is that path, so a link into a
+ * developer worktree publishes an absolute home path with no file to notice it in. The
+ * content pass cannot reach it: that pass decides text-ness by extension, and a symlink is
+ * named after whatever it stands in for. Mode 120000 is the only marker there is.
+ *
+ * @param {string} listing NUL-separated `ls-files -s` or `ls-tree -r` output
+ * @param {number} shaAt index of the object id once the row before the tab is split on spaces
+ * @param {(sha:string)=>string} blob
+ */
+function symlinkRows(listing, shaAt, blob) {
+  const out = [];
+  for (const row of listing.split('\0')) {
+    if (!row.startsWith('120000 ')) continue;
+    const tab = row.indexOf('\t');
+    if (tab < 0) continue;
+    const sha = row.slice(0, tab).split(/\s+/)[shaAt];
+    try { out.push({ path: row.slice(tab + 1), target: blob(sha) }); } catch { /* unreadable */ }
+  }
+  return out;
 }
 
 /* -------------------------------------------------------------------------- */
@@ -368,6 +398,15 @@ function scan(paths, allTracked, src) {
   const findings = [];
   const contentRules = RULES.filter((r) => r.kind === 'content');
   const pathRules = RULES.filter((r) => r.kind === 'path');
+
+  /* --- symlinks: the blob IS a path, and no extension makes it look like text --- */
+  for (const { path, target } of src.links()) {
+    if (matchesAny(path, CONFIG.excludePaths)) continue;
+    const applicable = contentRules.filter((r) => ruleApplies(r, path));
+    if (applicable.length === 0) continue;
+    matchContent(applicable.map((rule) => ({ rule, re: compile(rule) })),
+      [target], path, findings, new Set());
+  }
 
   for (const path of paths) {
     if (matchesAny(path, CONFIG.excludePaths)) continue;

--- a/.github/scripts/leakcheck.selftest.mjs
+++ b/.github/scripts/leakcheck.selftest.mjs
@@ -26,7 +26,7 @@
  */
 
 import { execFileSync } from 'node:child_process';
-import { mkdtempSync, mkdirSync, writeFileSync, cpSync, rmSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, writeFileSync, symlinkSync, cpSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -159,6 +159,15 @@ const CASES = [
     quiet: ['dev-machine-path', 'personal-data', 'credential-material'],
   },
   {
+    // A symlink is published as a blob holding its target, and it is named after whatever it
+    // stands in for — so it carries no extension, and the content pass, which decides
+    // text-ness by extension, walked straight past it. One shipped to two public
+    // repositories pointing at a developer worktree, and both gates stayed green.
+    path: 'a/node_modules',
+    link: '/Users/somebody/Work/checkout/node_modules',
+    expect: ['dev-machine-path'],
+  },
+  {
     path: 'docs/manual-test-something.md',
     body: '# a runbook\n',
     expect: ['internal-runbook'],
@@ -262,7 +271,8 @@ try {
 
   for (const c of CASES) {
     mkdirSync(join(root, dirname(c.path)), { recursive: true });
-    writeFileSync(join(root, c.path), c.body);
+    if (c.link) symlinkSync(c.link, join(root, c.path));
+    else writeFileSync(join(root, c.path), c.body);
   }
   git('add', '-A');
 

--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,8 @@
 
 # Dependencies. The plugin ships its bundles committed (see integrations/claude-code/.gitignore,
 # which re-includes hooks/dist and mcp/dist for that reason), but never its node_modules.
-node_modules/
+# No trailing slash: a worktree often symlinks this path, and `node_modules/` matches directories only.
+node_modules
 
 # Editor / OS noise
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ no `npm install` — the bundles ship committed.
 
 | Plugin | Version | Built for |
 | --- | --- | --- |
-| [`mubit-memory`](integrations/claude-code/) | 0.13.1 | [Claude Code](integrations/claude-code/) · [Codex CLI](integrations/codex/) |
+| [`mubit-memory`](integrations/claude-code/) | 0.13.2 | [Claude Code](integrations/claude-code/) · [Codex CLI](integrations/codex/) |
 
 You need two values before you start:
 

--- a/integrations/claude-code/.claude-plugin/plugin.json
+++ b/integrations/claude-code/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "mubit-memory",
   "displayName": "Mubit Memory",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "description": "Persistent, typed, self-improving memory for Claude Code, backed by Mubit. Captures work involuntarily, recalls relevant lessons before every prompt, and attributes outcomes so memory improves with use.",
   "author": { "name": "Mubit AI", "url": "https://mubit.ai" },
   "homepage": "https://docs.mubit.ai/integrations/claude-code",

--- a/integrations/claude-code/.gitignore
+++ b/integrations/claude-code/.gitignore
@@ -5,7 +5,8 @@
 # Claude Code installs a plugin by fetching the marketplace source.path from GitHub —
 # no install step, no npm install, no build. Whatever is committed is what runs, so
 # hooks/dist, mcp/dist and bin/statusline.mjs are committed artifacts (build-guide §11.3).
-node_modules/
+# No trailing slash: a worktree often symlinks this path, and `node_modules/` matches directories only.
+node_modules
 
 # The repo-root .gitignore excludes the build output of every Python/JS package in the
 # tree. This plugin's is committed on purpose (§11.3), so re-include it here — a deeper

--- a/integrations/claude-code/mcp/dist/index.js
+++ b/integrations/claude-code/mcp/dist/index.js
@@ -3140,7 +3140,7 @@ var BRIDGED = [
   ["MUBIT_CC_DATA_DIR", "CLAUDE_PLUGIN_DATA"]
 ];
 var UNEXPANDED = /^\$\{[A-Za-z_][A-Za-z0-9_]*\}$/;
-var SERVER_VERSION = true ? "0.13.1" : "";
+var SERVER_VERSION = true ? "0.13.2" : "";
 if (prepare(process.env)) {
   await import("./server.js");
 }

--- a/integrations/claude-code/package-lock.json
+++ b/integrations/claude-code/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mubit-ai/claude-code-plugin",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mubit-ai/claude-code-plugin",
-      "version": "0.13.1",
+      "version": "0.13.2",
       "license": "Apache-2.0",
       "devDependencies": {
         "@mubit-ai/mcp": "file:../mcp",

--- a/integrations/claude-code/package.json
+++ b/integrations/claude-code/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mubit-ai/claude-code-plugin",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "type": "module",
   "description": "Mubit memory plugin for Claude Code — involuntary capture, pre-prompt recall, and outcome attribution.",
   "license": "Apache-2.0",

--- a/integrations/codex/.codex-plugin/plugin.json
+++ b/integrations/codex/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mubit-memory",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "description": "Persistent, typed, self-improving memory for OpenAI Codex, backed by Mubit. Captures work involuntarily, recalls relevant lessons before every prompt, and attributes outcomes so memory improves with use. Shares one memory with the Claude Code plugin when both run in the same directory.",
   "author": {
     "name": "Mubit AI",

--- a/integrations/codex/mcp/dist/index.js
+++ b/integrations/codex/mcp/dist/index.js
@@ -3140,7 +3140,7 @@ var BRIDGED = [
   ["MUBIT_CC_DATA_DIR", "CLAUDE_PLUGIN_DATA"]
 ];
 var UNEXPANDED = /^\$\{[A-Za-z_][A-Za-z0-9_]*\}$/;
-var SERVER_VERSION = true ? "0.13.1" : "";
+var SERVER_VERSION = true ? "0.13.2" : "";
 if (prepare(process.env)) {
   await import("./server.js");
 }

--- a/integrations/codex/package.json
+++ b/integrations/codex/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mubit-ai/codex-plugin",
-  "version": "0.13.1",
+  "version": "0.13.2",
   "type": "module",
   "description": "Mubit memory plugin for OpenAI Codex CLI — involuntary capture, pre-prompt recall, and outcome attribution.",
   "license": "Apache-2.0",


### PR DESCRIPTION
Cuts the version to **0.13.2** and fixes a leak the 0.13.1 publish shipped to both public repos.

## The version bump

The nine files the previous bump touched: the two marketplace manifests, the root README badge, both plugin manifests, both `package.json`, the lockfile, and both `mcp/dist/index.js` (the version is inlined at build time, so the bundles are rebuilt).

## The leak

`main` and `mubit-ai/plugins` both track `integrations/claude-code/node_modules` as a **symlink**. Its blob content is an absolute path into a developer worktree. Two independent blind spots let it through:

- **The ignore pattern.** `node_modules/` has a trailing slash, so it matches directories. A symlink of that name is not a directory, so it was never ignored, and a release worktree that symlinks its dependencies gets it staged by `git add`.
- **The scanner.** A symlink is published as a blob holding its target path, and it is named after whatever it stands in for, so it carries no extension. `leakcheck` decides text-ness by extension, so the content pass walked straight past it in both working-tree and `--rev` mode.

Both are fixed here. The scanner now reads symlink targets through mode `120000` and runs the content rules over them, and the selftest gains a fixture that is red without the scanner change.

Verified: scanning `origin/main` with the patched gate reports `BLOCKING — 1  dev-machine-path`, on exactly that path. The release branch drops the file, so 0.13.2 does not republish it.

## Gates

| Gate | Result |
| --- | --- |
| Claude Code, source target | 1961 pass, 0 fail |
| Claude Code, dist target | 1961 pass, 0 fail |
| `verify-manifests` | pass |
| Codex, run alone | 436 pass, 0 fail |
| `leakcheck --strict` | exit 0, 715 warnings, 0 blocking |
| `leakcheck.selftest` | 15 cases ok |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H5Xms8fkWmDD6sftyLNeK8